### PR TITLE
Cannon research change

### DIFF
--- a/script/campaign/transitionTech.js
+++ b/script/campaign/transitionTech.js
@@ -17,7 +17,7 @@ const ALPHA_RESEARCH_NEW = [
 	// 4
 	"R-Wpn-Flamer-Damage02", "R-Wpn-Mortar01Lt", "R-Vehicle-Prop-Halftracks",
 	"R-Wpn-Cannon1Mk1", "R-Wpn-Mortar-Damage01", "R-Wpn-Mortar-Damage02",
-	"R-Wpn-Mortar-ROF01","R-Wpn-Cannon-Damage01", "R-Wpn-Cannon-Damage02",
+	"R-Wpn-Mortar-ROF01","R-Wpn-Cannon-Damage01",
 
 	// 5
 	"R-Struc-Factory-Module", "R-Wpn-Flamer-Damage03",
@@ -32,7 +32,7 @@ const ALPHA_RESEARCH_NEW = [
 	// 6
 	"R-Wpn-Cannon2Mk1", "R-Defense-WallTower03", "R-Wpn-Rocket05-MiniPod", "R-Struc-Research-Module",
 	"R-Vehicle-Prop-Tracks", "R-Vehicle-Engine01", "R-Defense-Tower06", "R-Defense-Pillbox06",
-	"R-Wpn-Rocket-Damage01", "R-Wpn-Rocket-Damage02", "R-Wpn-Rocket-ROF01",
+	"R-Wpn-Rocket-Damage01", "R-Wpn-Rocket-Damage02", "R-Wpn-Rocket-ROF01", "R-Wpn-Cannon-Damage02",
 	"R-Wpn-Rocket-ROF02", "R-Wpn-Rocket-ROF03", "R-Defense-WallTower06",
 	"R-Wpn-Rocket01-LtAT", "R-Wpn-Rocket03-HvAT", "R-Wpn-RocketSlow-Damage01",
 

--- a/stats/research.json
+++ b/stats/research.json
@@ -2305,7 +2305,7 @@
         "name": "Medium Cannon",
         "requiredResearch": [
             "R-Struc-Factory-Module",
-            "R-Wpn-Cannon-Damage02"
+            "R-Wpn-Cannon-Damage01"
         ],
         "researchPoints": 4800,
         "researchPower": 150,

--- a/stats/research.json
+++ b/stats/research.json
@@ -2228,7 +2228,7 @@
         "id": "R-Wpn-Cannon-Damage02",
         "name": "HEAT Cannon Shells Mk2",
         "requiredResearch": [
-            "R-Wpn-Cannon-Damage01"
+            "R-Wpn-Cannon2Mk1"
         ],
         "researchPoints": 2400,
         "researchPower": 75,

--- a/stats/research.json
+++ b/stats/research.json
@@ -2228,7 +2228,8 @@
         "id": "R-Wpn-Cannon-Damage02",
         "name": "HEAT Cannon Shells Mk2",
         "requiredResearch": [
-            "R-Wpn-Cannon2Mk1"
+            "R-Wpn-Cannon-Damage01",
+			"R-Wpn-Cannon2Mk1"
         ],
         "researchPoints": 2400,
         "researchPower": 75,


### PR DESCRIPTION
I tried to move the second Cannon damage upgrade to Alpha 06 and the Medium Cannon as a prerequisite of it, but it doesn't work. What am I doing wrong?