### PR TITLE
Log fix

### DIFF
--- a/stats/research.json
+++ b/stats/research.json
@@ -1258,9 +1258,6 @@
         "id": "R-Defense-Tower03",
         "msgName": "RES_TOWER3",
         "name": "Heavy Machinegun Guard Tower",
-        "redComponents": [
-            "GuardTower1"
-        ],
         "requiredResearch": [
             "R-Wpn-MG3Mk1"
         ],


### PR DESCRIPTION
With PR #1535 at the master version research cycles were detected. This leads to the following info in the logs:
`info    |21:25:54: [loadResearch:340] Invalid item 'GuardTower1' in list of redundant components of research 'Heavy Machinegun Guard Tower'`
`info    |21:25:54: [loadResearch:340] Assert in Warzone: D:\a\warzone2100\warzone2100\src\src\research.cpp:340 (false), last script event: ''`
This PR fixes it.