### PR TITLE
Rocket changes

### DIFF
--- a/script/campaign/cam1-3.js
+++ b/script/campaign/cam1-3.js
@@ -9,7 +9,7 @@ const NEW_PARADIGM_RES = [
 	"R-Sys-Engineering01", "R-Wpn-MG-Damage03", "R-Wpn-MG-ROF01", "R-Wpn-Cannon-Damage01",
 	"R-Wpn-Flamer-Damage03", "R-Wpn-Flamer-Range01", "R-Wpn-Flamer-ROF01",
 	"R-Defense-WallUpgrade02","R-Struc-Materials02", "R-Vehicle-Engine01",
-	"R-Struc-RprFac-Upgrade01", "R-Wpn-Rocket-Damage02", "R-Wpn-Rocket-ROF01",
+	"R-Struc-RprFac-Upgrade01", "R-Wpn-Rocket-Damage01", "R-Wpn-Rocket-ROF01",
 	"R-Wpn-Mortar-Damage02", "R-Wpn-Mortar-ROF01",
 ];
 const SCAVENGER_RES = [

--- a/script/campaign/cam1-4a.js
+++ b/script/campaign/cam1-4a.js
@@ -13,7 +13,7 @@ const NEW_PARADIGM_RES = [
 ];
 const SCAVENGER_RES = [
 	"R-Wpn-Flamer-Damage03", "R-Wpn-Flamer-Range01", "R-Wpn-Flamer-ROF01",
-	"R-Wpn-MG-Damage04", "R-Wpn-MG-ROF01", "R-Wpn-Rocket-Damage03",
+	"R-Wpn-MG-Damage04", "R-Wpn-MG-ROF01", "R-Wpn-Rocket-Damage02",
 	"R-Wpn-Cannon-Damage02", "R-Wpn-Mortar-Damage03", "R-Wpn-Mortar-ROF01",
 	"R-Wpn-Rocket-Accuracy01", "R-Wpn-Rocket-ROF03", "R-Vehicle-Metals02",
 	"R-Defense-WallUpgrade03", "R-Struc-Materials03",

--- a/script/campaign/cam1-4a.js
+++ b/script/campaign/cam1-4a.js
@@ -166,7 +166,7 @@ function eventStartLevel()
 		"NPCommandCenter": { tech: "R-Vehicle-Metals01" },
 		"NPResearchFacility": { tech: "R-Wpn-MG-Damage04" },
 		"MediumNPFactory": { tech: "R-Wpn-Rocket02-MRL" },
-		"HeavyNPFactory": { tech: "R-Wpn-Rocket-Damage03" },
+		"HeavyNPFactory": { tech: "R-Wpn-Rocket-Damage02" },
 	});
 
 	camSetFactories({

--- a/script/campaign/cam1-4a.js
+++ b/script/campaign/cam1-4a.js
@@ -7,7 +7,7 @@ const NEW_PARADIGM_RES = [
 	"R-Sys-Engineering01", "R-Wpn-MG-Damage04", "R-Wpn-MG-ROF01", "R-Wpn-Cannon-Damage03",
 	"R-Wpn-Flamer-Damage03", "R-Wpn-Flamer-Range01", "R-Wpn-Flamer-ROF01",
 	"R-Defense-WallUpgrade03","R-Struc-Materials03", "R-Vehicle-Engine02",
-	"R-Struc-RprFac-Upgrade03", "R-Wpn-Rocket-Damage03", "R-Wpn-Rocket-ROF03",
+	"R-Struc-RprFac-Upgrade03", "R-Wpn-Rocket-Damage02", "R-Wpn-Rocket-ROF03",
 	"R-Vehicle-Metals02", "R-Wpn-Mortar-Damage03", "R-Wpn-Rocket-Accuracy02",
 	"R-Wpn-RocketSlow-Damage02", "R-Wpn-Mortar-ROF01",
 ];

--- a/script/campaign/cam1-5.js
+++ b/script/campaign/cam1-5.js
@@ -7,14 +7,14 @@ const NEW_PARADIGM_RES = [
 	"R-Sys-Engineering01", "R-Wpn-MG-Damage04", "R-Wpn-MG-ROF02", "R-Wpn-Cannon-Damage03",
 	"R-Wpn-Flamer-Damage03", "R-Wpn-Flamer-Range01", "R-Wpn-Flamer-ROF01",
 	"R-Defense-WallUpgrade03","R-Struc-Materials03", "R-Vehicle-Engine02",
-	"R-Struc-RprFac-Upgrade03", "R-Wpn-Rocket-Damage03", "R-Wpn-Rocket-ROF03",
+	"R-Struc-RprFac-Upgrade03", "R-Wpn-Rocket-Damage02", "R-Wpn-Rocket-ROF03",
 	"R-Vehicle-Metals02", "R-Wpn-Mortar-Damage03", "R-Wpn-Rocket-Accuracy02",
 	"R-Wpn-RocketSlow-Damage02", "R-Wpn-Mortar-ROF01", "R-Cyborg-Metals03",
 	"R-Wpn-Mortar-Acc01", "R-Wpn-RocketSlow-Accuracy01", "R-Wpn-Cannon-Accuracy01",
 ];
 const SCAVENGER_RES = [
 	"R-Wpn-Flamer-Damage03", "R-Wpn-Flamer-Range01", "R-Wpn-Flamer-ROF01",
-	"R-Wpn-MG-Damage04", "R-Wpn-MG-ROF01", "R-Wpn-Rocket-Damage03",
+	"R-Wpn-MG-Damage04", "R-Wpn-MG-ROF01", "R-Wpn-Rocket-Damage02",
 	"R-Wpn-Cannon-Damage03", "R-Wpn-Mortar-Damage03", "R-Wpn-Mortar-ROF01",
 	"R-Wpn-Rocket-Accuracy02", "R-Wpn-Rocket-ROF03", "R-Vehicle-Metals02",
 	"R-Defense-WallUpgrade03", "R-Struc-Materials03", "R-Wpn-Cannon-Accuracy01",

--- a/script/campaign/cam1-7.js
+++ b/script/campaign/cam1-7.js
@@ -104,7 +104,7 @@ function eventGroupLoss(obj, group, newsize)
 			addLabel(acrate, "newArtiLabel");
 
 			camSetArtifacts({
-				"newArtiLabel": { tech: ["R-Wpn-Cannon3Mk1", "R-Wpn-RocketSlow-Damage03"] }
+				"newArtiLabel": { tech: ["R-Wpn-Cannon3Mk1", "R-Wpn-RocketSlow-Damage03", "R-Wpn-Rocket-Damage03"] }
 			});
 
 			droidWithArtiID = undefined;

--- a/script/campaign/cam1c.js
+++ b/script/campaign/cam1c.js
@@ -7,13 +7,13 @@ const NEW_PARADIGM_RES = [
 	"R-Sys-Engineering01", "R-Wpn-MG-Damage03", "R-Wpn-MG-ROF01", "R-Wpn-Cannon-Damage02",
 	"R-Wpn-Flamer-Damage03", "R-Wpn-Flamer-Range01", "R-Wpn-Flamer-ROF01",
 	"R-Defense-WallUpgrade03","R-Struc-Materials03", "R-Vehicle-Engine02",
-	"R-Struc-RprFac-Upgrade02", "R-Wpn-Rocket-Damage02", "R-Wpn-Rocket-ROF03",
+	"R-Struc-RprFac-Upgrade02", "R-Wpn-Rocket-Damage01", "R-Wpn-Rocket-ROF03",
 	"R-Vehicle-Metals01", "R-Wpn-Mortar-Damage02", "R-Wpn-Rocket-Accuracy02",
 	"R-Wpn-Mortar-ROF01",
 ];
 const SCAVENGER_RES = [
 	"R-Wpn-Flamer-Damage02", "R-Wpn-Flamer-Range01", "R-Wpn-Flamer-ROF01",
-	"R-Wpn-MG-Damage03", "R-Wpn-MG-ROF01", "R-Wpn-Rocket-Damage02",
+	"R-Wpn-MG-Damage03", "R-Wpn-MG-ROF01", "R-Wpn-Rocket-Damage01",
 	"R-Wpn-Cannon-Damage02", "R-Wpn-Mortar-Damage02", "R-Wpn-Mortar-ROF01",
 	"R-Wpn-Rocket-ROF03", "R-Defense-WallUpgrade03","R-Struc-Materials03",
 ];

--- a/script/campaign/cam1ca.js
+++ b/script/campaign/cam1ca.js
@@ -7,7 +7,7 @@ const NEW_PARADIGM_RES = [
 	"R-Sys-Engineering01", "R-Wpn-MG-Damage03", "R-Wpn-MG-ROF01", "R-Wpn-Cannon-Damage02",
 	"R-Wpn-Flamer-Damage03", "R-Wpn-Flamer-Range01", "R-Wpn-Flamer-ROF01",
 	"R-Defense-WallUpgrade03","R-Struc-Materials03", "R-Vehicle-Engine02",
-	"R-Struc-RprFac-Upgrade02", "R-Wpn-Rocket-Damage02", "R-Wpn-Rocket-ROF03",
+	"R-Struc-RprFac-Upgrade02", "R-Wpn-Rocket-Damage01", "R-Wpn-Rocket-ROF03",
 	"R-Vehicle-Metals01", "R-Wpn-Mortar-Damage02", "R-Wpn-Rocket-Accuracy02",
 	"R-Wpn-Mortar-ROF01",
 ];

--- a/stats/research.json
+++ b/stats/research.json
@@ -2256,7 +2256,7 @@
         "name": "HEAT Cannon Shells Mk3",
         "requiredResearch": [
             "R-Wpn-Cannon-Damage02",
-            "R-Wpn-Rocket-Damage03"
+            "R-Wpn-Rocket-Damage02"
         ],
         "researchPoints": 3600,
         "researchPower": 112,
@@ -2944,14 +2944,14 @@
                 "filterParameter": "ImpactClass",
                 "filterValue": "ROCKET",
                 "parameter": "Damage",
-                "value": 30
+                "value": 60
             },
             {
                 "class": "Weapon",
                 "filterParameter": "ImpactClass",
                 "filterValue": "ROCKET",
                 "parameter": "RadiusDamage",
-                "value": 30
+                "value": 60
             }
         ],
         "statID": "Rocket-Pod",
@@ -2960,6 +2960,7 @@
     "R-Wpn-Rocket-Damage02": {
         "iconID": "IMAGE_RES_WEAPONTECH",
         "id": "R-Wpn-Rocket-Damage02",
+        "keyTopic": 1,
         "name": "HE Mini-Rockets Mk2",
         "requiredResearch": [
             "R-Wpn-Rocket-Damage01"
@@ -2972,14 +2973,14 @@
                 "filterParameter": "ImpactClass",
                 "filterValue": "ROCKET",
                 "parameter": "Damage",
-                "value": 30
+                "value": 60
             },
             {
                 "class": "Weapon",
                 "filterParameter": "ImpactClass",
                 "filterValue": "ROCKET",
                 "parameter": "RadiusDamage",
-                "value": 30
+                "value": 60
             }
         ],
         "statID": "Rocket-Pod",
@@ -2989,10 +2990,10 @@
     "R-Wpn-Rocket-Damage03": {
         "iconID": "IMAGE_RES_WEAPONTECH",
         "id": "R-Wpn-Rocket-Damage03",
-        "keyTopic": 1,
         "name": "HE Mini-Rockets Mk3",
         "requiredResearch": [
-            "R-Wpn-Rocket-Damage02"
+            "R-Wpn-Cannon3Mk1",
+			"R-Wpn-Rocket-Damage02"
         ],
         "researchPoints": 3600,
         "researchPower": 112,
@@ -3002,14 +3003,14 @@
                 "filterParameter": "ImpactClass",
                 "filterValue": "ROCKET",
                 "parameter": "Damage",
-                "value": 100
+                "value": 60
             },
             {
                 "class": "Weapon",
                 "filterParameter": "ImpactClass",
                 "filterValue": "ROCKET",
                 "parameter": "RadiusDamage",
-                "value": 100
+                "value": 60
             }
         ],
         "statID": "Rocket-Pod",
@@ -3290,7 +3291,7 @@
         "name": "HEAT Rocket Warhead Mk2",
         "requiredResearch": [
             "R-Wpn-RocketSlow-Damage01",
-            "R-Wpn-Rocket-Damage03"
+            "R-Wpn-Rocket-Damage02"
         ],
         "researchPoints": 3600,
         "researchPower": 112,
@@ -5854,14 +5855,14 @@
                 "filterParameter": "ImpactClass",
                 "filterValue": "ROCKET",
                 "parameter": "Damage",
-                "value": 30
+                "value": 60
             },
             {
                 "class": "Weapon",
                 "filterParameter": "ImpactClass",
                 "filterValue": "ROCKET",
                 "parameter": "RadiusDamage",
-                "value": 30
+                "value": 60
             }
         ],
         "statID": "Rocket-Pod",
@@ -5883,14 +5884,14 @@
                 "filterParameter": "ImpactClass",
                 "filterValue": "ROCKET",
                 "parameter": "Damage",
-                "value": 30
+                "value": 60
             },
             {
                 "class": "Weapon",
                 "filterParameter": "ImpactClass",
                 "filterValue": "ROCKET",
                 "parameter": "RadiusDamage",
-                "value": 30
+                "value": 60
             }
         ],
         "statID": "Rocket-Pod",

--- a/stats/research.json
+++ b/stats/research.json
@@ -2990,9 +2990,9 @@
     "R-Wpn-Rocket-Damage03": {
         "iconID": "IMAGE_RES_WEAPONTECH",
         "id": "R-Wpn-Rocket-Damage03",
+		"keyTopic": 1,
         "name": "HE Mini-Rockets Mk3",
         "requiredResearch": [
-            "R-Wpn-Cannon3Mk1",
 			"R-Wpn-Rocket-Damage02"
         ],
         "researchPoints": 3600,


### PR DESCRIPTION
With the changes for the MRA, the MRA used by the NP became too strong according to Discord member Dziq. I moved the rocket damage upgrade 2 to Alpha 08 and upgrade 3 to Alpha 11. Therefore the values for the upgrades also changed and some damage upgrades get stripped from the Scavs and the NP.