### PR TITLE
Updating Gamma 04

### DIFF
--- a/script/campaign/cam3-2.js
+++ b/script/campaign/cam3-2.js
@@ -296,6 +296,6 @@ function eventStartLevel()
 	queue("setAlphaExp", camSecondsToMilliseconds(2));
 	queue("setupPatrolGroups", camMinutesToMilliseconds(1.5));
 
-	setTimer("phantomFactoryNE", camChangeOnDiff(camMinutesToMilliseconds(4)));
-	setTimer("phantomFactorySW", camChangeOnDiff(camMinutesToMilliseconds(6)));
+	setTimer("phantomFactoryNE", camChangeOnDiff(camMinutesToMilliseconds(3.5)));
+	setTimer("phantomFactorySW", camChangeOnDiff(camMinutesToMilliseconds(5.5)));
 }


### PR DESCRIPTION
I made some tests and even with Insane difficulty the player has too much time for preparation. Cutting the reinforcement time for the NE group to 3 minutes gives him not enough time, therefore I set it to 3.5 minutes. I also set the reinforcement time for the SW group 30 seconds shorter due to the same reasons. This also avoids that both groups are coming together and causing insolvable problems. Bringing back phantomFactoryNE() is also too tough.