### PR TITLE
weaponmodifier adjustment

### DIFF
--- a/stats/weaponmodifier.json
+++ b/stats/weaponmodifier.json
@@ -1,10 +1,10 @@
 {
     "ALL ROUNDER": {
         "Half-Tracked": 105,
-        "Hover": 95,
+        "Hover": 100,
         "Legged": 60,
         "Lift": 100,
-        "Tracked": 100,
+        "Tracked": 95,
         "Wheeled": 110
     },
     "ANTI PERSONNEL": {
@@ -17,19 +17,19 @@
     },
     "ANTI TANK": {
         "Half-Tracked": 120,
-        "Hover": 110,
+        "Hover": 115,
         "Legged": 30,
         "Lift": 20,
-        "Tracked": 115,
+        "Tracked": 110,
         "Wheeled": 125
     },
     "ARTILLERY ROUND": {
         "Half-Tracked": 100,
-        "Hover": 120,
+        "Hover": 90,
         "Legged": 125,
         "Lift": 100,
         "Tracked": 80,
-        "Wheeled": 130
+        "Wheeled": 110
     },
     "BUNKER BUSTER": {
         "Half-Tracked": 33,


### PR DESCRIPTION
Even that most players will never see the modifiers, from a logical point it makes no sense that Hover tanks are having a lower modifier than tracked tanks. Therefore I switched these modifiers in ALL ROUNDER and ANTI TANK. Also the modifiers in ARTILLERY ROUND against Hover and wheeled tanks are too high in my eyes, so they get decreased. Even though the modifier against legged units in ARTILLERY ROUND is higher than the modifier in ANTI PERSONNEL I didn't change it because it would become too difficult to destroy Nexus Cyborgs with artillery. Especially in Gamma 04.