### PR TITLE
Scav Flamer ROF change

### DIFF
--- a/stats/weapons.json
+++ b/stats/weapons.json
@@ -221,7 +221,7 @@
         "effectSize": 1,
         "facePlayer": 1,
         "fireOnMove": 1,
-        "firePause": 20,
+        "firePause": 30,
         "flightGfx": "FXLThrow.PIE",
         "flightSpeed": 600,
         "hitGfx": "FXMETHIT.PIE",


### PR DESCRIPTION
There were some complaints about the strength of the Scav flamer. Therefore, after some tests, I decreased the ROF to 20 from 30.