### PR TITLE
Scorpion move

### DIFF
--- a/script/campaign/cam1-5.js
+++ b/script/campaign/cam1-5.js
@@ -213,9 +213,8 @@ function eventStartLevel()
 	});
 
 	camSetArtifacts({
-		"NPCyborgFactory": { tech: "R-Struc-Factory-Upgrade03" },
 		"NPRightFactory": { tech: "R-Vehicle-Engine02" },
-		"NPLeftFactory": { tech: "R-Vehicle-Body08" }, //scorpion body
+		"NPLeftFactory": { tech: "R-Struc-Factory-Upgrade03" },
 		"NPResearchFacility": { tech: "R-Comp-SynapticLink" },
 	});
 

--- a/stats/research.json
+++ b/stats/research.json
@@ -2154,13 +2154,12 @@
     "R-Vehicle-Body08": {
         "iconID": "IMAGE_RES_DROIDTECH",
         "id": "R-Vehicle-Body08",
-        "keyTopic": 1,
         "msgName": "RES_V_B08",
         "name": "Medium Body - Scorpion",
         "requiredResearch": [
             "R-Vehicle-Body05",
 			"R-Vehicle-Body04",
-            "R-Vehicle-Metals02"
+            "R-Vehicle-Metals01"
         ],
         "researchPoints": 2400,
         "researchPower": 75,


### PR DESCRIPTION
Discord member Dziq mentioned that from a logical point it makes more sense to research the Scorpion body earlier than the Python body. Therefore the Scorpion body is moved from Alpha 09 to Alpha 08 with Composite Alloys Mk1 as the prerequisite.