### PR TITLE
Nexus wall/structure armor changes

### DIFF
--- a/script/campaign/cam3-1.js
+++ b/script/campaign/cam3-1.js
@@ -2,7 +2,7 @@ include("script/campaign/libcampaign.js");
 include("script/campaign/templates.js");
 
 const NEXUS_RES = [
-	"R-Sys-Engineering03", "R-Defense-WallUpgrade08", "R-Struc-Materials08",
+	"R-Sys-Engineering03", "R-Defense-WallUpgrade07", "R-Struc-Materials07",
 	"R-Struc-VTOLPad-Upgrade06", "R-Wpn-Bomb-Damage03", "R-Sys-NEXUSrepair",
 	"R-Vehicle-Prop-Hover02", "R-Vehicle-Prop-VTOL02", "R-Cyborg-Legs02",
 	"R-Wpn-Mortar-Acc03", "R-Wpn-MG-Damage09", "R-Wpn-Mortar-ROF04",

--- a/script/campaign/cam3-2.js
+++ b/script/campaign/cam3-2.js
@@ -4,7 +4,7 @@ include("script/campaign/transitionTech.js");
 
 const ALPHA = 1; //Team alpha units belong to player 1.
 const NEXUS_RES = [
-	"R-Sys-Engineering03", "R-Defense-WallUpgrade09", "R-Struc-Materials09",
+	"R-Sys-Engineering03", "R-Defense-WallUpgrade08", "R-Struc-Materials08",
 	"R-Struc-VTOLPad-Upgrade06", "R-Wpn-Bomb-Damage03", "R-Sys-NEXUSrepair",
 	"R-Vehicle-Prop-Hover02", "R-Vehicle-Prop-VTOL02", "R-Cyborg-Legs02",
 	"R-Wpn-Mortar-Acc03", "R-Wpn-MG-Damage09", "R-Wpn-Mortar-ROF04",

--- a/script/campaign/cam3-a.js
+++ b/script/campaign/cam3-a.js
@@ -160,7 +160,7 @@ function groupPatrolNoTrigger()
 function cam3Setup()
 {
 	const NEXUS_RES = [
-		"R-Sys-Engineering03", "R-Defense-WallUpgrade08", "R-Struc-Materials08",
+		"R-Sys-Engineering03", "R-Defense-WallUpgrade07", "R-Struc-Materials07",
 		"R-Struc-VTOLPad-Upgrade06", "R-Wpn-Bomb-Damage03", "R-Sys-NEXUSrepair",
 		"R-Vehicle-Prop-Hover02", "R-Vehicle-Prop-VTOL02", "R-Cyborg-Legs02",
 		"R-Wpn-Mortar-Acc03", "R-Wpn-MG-Damage08", "R-Wpn-Mortar-ROF04",

--- a/stats/research.json
+++ b/stats/research.json
@@ -6690,14 +6690,14 @@
                 "filterParameter": "Type",
                 "filterValue": "Wall",
                 "parameter": "Armour",
-                "value": 30
+                "value": 40
             },
             {
                 "class": "Building",
                 "filterParameter": "Type",
                 "filterValue": "Wall",
                 "parameter": "HitPoints",
-                "value": 30
+                "value": 40
             }
         ],
         "subgroupIconID": "IMAGE_RES_GRPUPG"
@@ -6718,14 +6718,14 @@
                 "filterParameter": "Type",
                 "filterValue": "Wall",
                 "parameter": "Armour",
-                "value": 30
+                "value": 20
             },
             {
                 "class": "Building",
                 "filterParameter": "Type",
                 "filterValue": "Wall",
                 "parameter": "HitPoints",
-                "value": 30
+                "value": 20
             }
         ],
         "subgroupIconID": "IMAGE_RES_GRPUPG",
@@ -6747,14 +6747,14 @@
                 "filterParameter": "Type",
                 "filterValue": "Wall",
                 "parameter": "Armour",
-                "value": 30
+                "value": 40
             },
             {
                 "class": "Building",
                 "filterParameter": "Type",
                 "filterValue": "Wall",
                 "parameter": "HitPoints",
-                "value": 30
+                "value": 40
             }
         ],
         "subgroupIconID": "IMAGE_RES_GRPUPG",
@@ -6771,14 +6771,14 @@
                 "filterParameter": "Type",
                 "filterValue": "Wall",
                 "parameter": "Armour",
-                "value": 90
+                "value": 100
             },
             {
                 "class": "Building",
                 "filterParameter": "Type",
                 "filterValue": "Wall",
                 "parameter": "HitPoints",
-                "value": 90
+                "value": 100
             }
         ],
         "subgroupIconID": "IMAGE_RES_GRPUPG",
@@ -6795,14 +6795,14 @@
                 "filterParameter": "Type",
                 "filterValue": "Wall",
                 "parameter": "Armour",
-                "value": 90
+                "value": 400
             },
             {
                 "class": "Building",
                 "filterParameter": "Type",
                 "filterValue": "Wall",
                 "parameter": "HitPoints",
-                "value": 90
+                "value": 400
             }
         ],
         "subgroupIconID": "IMAGE_RES_GRPUPG",
@@ -6826,14 +6826,14 @@
                 "filterParameter": "Type",
                 "filterValue": "Structure",
                 "parameter": "Armour",
-                "value": 30
+                "value": 40
             },
             {
                 "class": "Building",
                 "filterParameter": "Type",
                 "filterValue": "Structure",
                 "parameter": "HitPoints",
-                "value": 30
+                "value": 40
             }
         ],
         "subgroupIconID": "IMAGE_RES_GRPUPG"
@@ -6854,14 +6854,14 @@
                 "filterParameter": "Type",
                 "filterValue": "Structure",
                 "parameter": "Armour",
-                "value": 30
+                "value": 20
             },
             {
                 "class": "Building",
                 "filterParameter": "Type",
                 "filterValue": "Structure",
                 "parameter": "HitPoints",
-                "value": 30
+                "value": 20
             }
         ],
         "subgroupIconID": "IMAGE_RES_GRPUPG",
@@ -6883,14 +6883,14 @@
                 "filterParameter": "Type",
                 "filterValue": "Structure",
                 "parameter": "Armour",
-                "value": 30
+                "value": 40
             },
             {
                 "class": "Building",
                 "filterParameter": "Type",
                 "filterValue": "Structure",
                 "parameter": "HitPoints",
-                "value": 30
+                "value": 40
             }
         ],
         "subgroupIconID": "IMAGE_RES_GRPUPG",
@@ -6907,14 +6907,14 @@
                 "filterParameter": "Type",
                 "filterValue": "Structure",
                 "parameter": "Armour",
-                "value": 90
+                "value": 100
             },
             {
                 "class": "Building",
                 "filterParameter": "Type",
                 "filterValue": "Structure",
                 "parameter": "HitPoints",
-                "value": 90
+                "value": 100
             }
         ],
         "subgroupIconID": "IMAGE_RES_GRPUPG",
@@ -6931,14 +6931,14 @@
                 "filterParameter": "Type",
                 "filterValue": "Structure",
                 "parameter": "Armour",
-                "value": 90
+                "value": 400
             },
             {
                 "class": "Building",
                 "filterParameter": "Type",
                 "filterValue": "Structure",
                 "parameter": "HitPoints",
-                "value": 90
+                "value": 400
             }
         ],
         "subgroupIconID": "IMAGE_RES_GRPUPG",

--- a/stats/research.json
+++ b/stats/research.json
@@ -6802,7 +6802,7 @@
                 "filterParameter": "Type",
                 "filterValue": "Wall",
                 "parameter": "HitPoints",
-                "value": 400
+                "value": 100
             }
         ],
         "subgroupIconID": "IMAGE_RES_GRPUPG",
@@ -6938,7 +6938,7 @@
                 "filterParameter": "Type",
                 "filterValue": "Structure",
                 "parameter": "HitPoints",
-                "value": 400
+                "value": 100
             }
         ],
         "subgroupIconID": "IMAGE_RES_GRPUPG",


### PR DESCRIPTION
Changed the values for Nexus wall/structure defense upgrades.
Gives now one upgrade for Gamma 1 and 2, two for Gamma 3 and 4, and three for Gamma 6.
Changed the values for Nexus only upgrades 10 and 11. The change for upgrade 11 seems very high but if my calculations are right it's necessary to keep Nexus' walls/structures strong enough against the Rail Gun in Gamma 9.