### PR TITLE
Adding the MRA to the red components of the Pepperpot

### DIFF
--- a/stats/research.json
+++ b/stats/research.json
@@ -6019,7 +6019,8 @@
         "msgName": "RES_W_M3",
         "name": "Rotary Mortar - Pepperpot",
         "redComponents": [
-            "Mortar2Mk1"
+            "Mortar2Mk1",
+			"Rocket-MRL"
         ],
         "requiredResearch": [
 			"R-Wpn-Mortar02Hvy"


### PR DESCRIPTION
The Pepperpot obsoletes the Bombard and because the Bombard is stronger than the MRA it should also obsolete the MRA.