### PR TITLE
Decreasing Rocket damage upgrade 4

### DIFF
--- a/stats/research.json
+++ b/stats/research.json
@@ -6050,14 +6050,14 @@
                 "filterParameter": "ImpactClass",
                 "filterValue": "ROCKET",
                 "parameter": "Damage",
-                "value": 40
+                "value": 30
             },
             {
                 "class": "Weapon",
                 "filterParameter": "ImpactClass",
                 "filterValue": "ROCKET",
                 "parameter": "RadiusDamage",
-                "value": 40
+                "value": 30
             }
         ],
         "statID": "Rocket-Pod",


### PR DESCRIPTION
Because the MRA became too powerful, the Rocket damage upgrade 4 is decreased after one Beta 1 run with the MRP and additional weapon tests