### PR TITLE
Decrease Rocket damage upgrade 5

### DIFF
--- a/stats/research.json
+++ b/stats/research.json
@@ -6079,14 +6079,14 @@
                 "filterParameter": "ImpactClass",
                 "filterValue": "ROCKET",
                 "parameter": "Damage",
-                "value": 30
+                "value": 20
             },
             {
                 "class": "Weapon",
                 "filterParameter": "ImpactClass",
                 "filterValue": "ROCKET",
                 "parameter": "RadiusDamage",
-                "value": 30
+                "value": 20
             }
         ],
         "statID": "Rocket-Pod",


### PR DESCRIPTION
Weapon tests showed that the MRA and the MRP are too powerful after Beta 3. Therefore the damage upgrade 5 is decreased.