### PR TITLE
Changing queue of Vtol attacks in Gamma 04

### DIFF
--- a/script/campaign/cam2-2.js
+++ b/script/campaign/cam2-2.js
@@ -228,6 +228,6 @@ function eventStartLevel()
 
 	hackAddMessage("C22_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER, true);
 
-	queue("vtolAttack", camMinutesToMilliseconds(2));
+	queue("vtolAttack", camSecondsToMilliseconds(1));
 	setTimer("truckDefense", camSecondsToMilliseconds(160));
 }


### PR DESCRIPTION
The queue for vtolAttack is added to the time in the vtolAttack function. With the result, that it last too long until the first VTOL attack takes place. Therefore the queue is decreased to one second.