### PR TITLE
Giving the Commander the damage zero

### DIFF
--- a/stats/weapons.json
+++ b/stats/weapons.json
@@ -1242,7 +1242,7 @@
 	"CommandTurret1": {
 		"buildPoints": 100,
 		"buildPower": 100,
-		"damage": 1,
+		"damage": 0,
 		"effectSize": 1,
 		"facePlayer": 1,
 		"firePause": 1,


### PR DESCRIPTION
Tests showed that the Commander is still working with the damage zero. Now he only marks the targets and deals no longer damage. As it should be in my eyes.