### PR TITLE
Increasing the Ground Shaker base damage a bit

### DIFF
--- a/stats/weapons.json
+++ b/stats/weapons.json
@@ -1785,7 +1785,7 @@
 	"Howitzer150Mk1": {
 		"buildPoints": 1250,
 		"buildPower": 350,
-		"damage": 120,
+		"damage": 150,
 		"designable": 1,
 		"effectSize": 200,
 		"explosionWav": "lrgexpl.ogg",


### PR DESCRIPTION
Because the Ground Shaker is the "Heavy Howitzer" it should have the highest base damage. Therefore the base damage is slightly increased.