### PR TITLE
Removing numRounds for the Needle Gun

### DIFF
--- a/stats/weapons.json
+++ b/stats/weapons.json
@@ -3279,7 +3279,6 @@
 		"muzzleGfx": "FXLGauss.PIE",
 		"name": "Needle Gun",
 		"numExplosions": 1,
-		"numRounds": 3,
 		"rotate": 180,
 		"shortHit": 80,
 		"shortRange": 1024,


### PR DESCRIPTION
numRounds is superfluous for the Needle Gun. Somehow I missed that all the time.