### PR TITLE
Increasing factory throttles in Beta 06

### DIFF
--- a/script/campaign/cam2-5.js
+++ b/script/campaign/cam2-5.js
@@ -137,7 +137,7 @@ function eventStartLevel()
 			assembly: "COMediumFactoryAssembly",
 			order: CAM_ORDER_ATTACK,
 			groupSize: 4,
-			throttle: camChangeOnDiff(camSecondsToMilliseconds(50)),
+			throttle: camChangeOnDiff(camSecondsToMilliseconds(55)),
 			data: {
 				regroup: false,
 				repair: 20,
@@ -161,7 +161,7 @@ function eventStartLevel()
 			assembly: "COCyborgFactoryRAssembly",
 			order: CAM_ORDER_ATTACK,
 			groupSize: 5,
-			throttle: camChangeOnDiff(camSecondsToMilliseconds(25)),
+			throttle: camChangeOnDiff(camSecondsToMilliseconds(45)),
 			data: {
 				regroup: false,
 				repair: 30,


### PR DESCRIPTION
Especially with Insane difficulty, it's way too difficult to make any progress with the current unit production. Therefore the factory throttles are increased to values comparable with the later levels.