### PR TITLE
Increase Rocket damage upgrade 6

### DIFF
--- a/stats/research.json
+++ b/stats/research.json
@@ -6109,14 +6109,14 @@
                 "filterParameter": "ImpactClass",
                 "filterValue": "ROCKET",
                 "parameter": "Damage",
-                "value": 10
+                "value": 30
             },
             {
                 "class": "Weapon",
                 "filterParameter": "ImpactClass",
                 "filterValue": "ROCKET",
                 "parameter": "RadiusDamage",
-                "value": 10
+                "value": 30
             }
         ],
         "statID": "Rocket-Pod",


### PR DESCRIPTION
Tests showed that it's necessary to increase the damage upgrade 6 to keep the MRP and the MRA viable choices.