### PR TITLE
Cannon rebalance

### DIFF
--- a/stats/research.json
+++ b/stats/research.json
@@ -4986,14 +4986,14 @@
                 "filterParameter": "ImpactClass",
                 "filterValue": "CANNON",
                 "parameter": "Damage",
-                "value": 20
+                "value": 25
             },
             {
                 "class": "Weapon",
                 "filterParameter": "ImpactClass",
                 "filterValue": "CANNON",
                 "parameter": "RadiusDamage",
-                "value": 20
+                "value": 25
             }
         ],
         "statID": "Cannon1Mk1",
@@ -5015,14 +5015,14 @@
                 "filterParameter": "ImpactClass",
                 "filterValue": "CANNON",
                 "parameter": "Damage",
-                "value": 20
+                "value": 30
             },
             {
                 "class": "Weapon",
                 "filterParameter": "ImpactClass",
                 "filterValue": "CANNON",
                 "parameter": "RadiusDamage",
-                "value": 20
+                "value": 30
             }
         ],
         "statID": "Cannon1Mk1",
@@ -7670,14 +7670,14 @@
                 "filterParameter": "ImpactClass",
                 "filterValue": "CANNON",
                 "parameter": "Damage",
-                "value": 10
+                "value": 5
             },
             {
                 "class": "Weapon",
                 "filterParameter": "ImpactClass",
                 "filterValue": "CANNON",
                 "parameter": "RadiusDamage",
-                "value": 10
+                "value": 5
             }
         ],
         "statID": "Cannon1Mk1",
@@ -7700,14 +7700,14 @@
                 "filterParameter": "ImpactClass",
                 "filterValue": "CANNON",
                 "parameter": "Damage",
-                "value": 10
+                "value": 5
             },
             {
                 "class": "Weapon",
                 "filterParameter": "ImpactClass",
                 "filterValue": "CANNON",
                 "parameter": "RadiusDamage",
-                "value": 10
+                "value": 5
             }
         ],
         "statID": "Cannon1Mk1",
@@ -7731,14 +7731,14 @@
                 "filterParameter": "ImpactClass",
                 "filterValue": "CANNON",
                 "parameter": "FirePause",
-                "value": -5
+                "value": -10
             },
             {
                 "class": "Weapon",
                 "filterParameter": "ImpactClass",
                 "filterValue": "CANNON",
                 "parameter": "ReloadTime",
-                "value": -5
+                "value": -10
             }
         ],
         "statID": "Cannon1Mk1",


### PR DESCRIPTION
In my calculations, the goal was that cannons are dealing between 2/3 and 3/4 of the damage an anti-tank weapon deals to a tank. This goal was missed due to the wrong accuracy values I set in my spreadsheet. Here are the tested changes (up to Beta 09) to the cannon damage upgrades that reach this goal again.