### PR TITLE
Light Cannon balance changes

### DIFF
--- a/stats/research.json
+++ b/stats/research.json
@@ -2410,8 +2410,7 @@
         "id": "R-Wpn-Cannon-Damage02",
         "name": "HEAT Cannon Shells Mk2",
         "requiredResearch": [
-            "R-Wpn-Cannon-Damage01",
-			"R-Wpn-Cannon2Mk1"
+            "R-Wpn-Cannon-Damage01"
         ],
         "researchPoints": 2400,
         "researchPower": 75,

--- a/stats/weaponmodifier.json
+++ b/stats/weaponmodifier.json
@@ -8,11 +8,11 @@
 		"Wheeled": 110
 	},
 	"ANTI PERSONNEL": {
-		"Half-Tracked": 75,
+		"Half-Tracked": 65,
 		"Hover": 100,
 		"Legged": 120,
 		"Lift": 25,
-		"Tracked": 60,
+		"Tracked": 50,
 		"Wheeled": 100
 	},
 	"ANTI TANK": {


### PR DESCRIPTION
Discord member VanitysFiend mentioned that the LC in Alpha 05 and Alpha 06 is weaker than the HMG and my calculations showed that he's right. Therefore the weaponmodifier for anti-personnel weapons is changed and the second cannon damage upgrade moved back to Alpha 04 from Alpha 06.