### PR TITLE
Beta 6 Hover activation timer change

### DIFF
--- a/script/campaign/cam2-5.js
+++ b/script/campaign/cam2-5.js
@@ -173,7 +173,7 @@ function eventStartLevel()
 
 	hackAddMessage("C25_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER, true);
 
-	queue("setupDamHovers", camChangeOnDiff(camMinutesToMilliseconds(4)));
+	queue("setupDamHovers", camSecondsToMilliseconds(3));
 	queue("setupCyborgsEast", camChangeOnDiff(camMinutesToMilliseconds(3)));
 	queue("enableFactories", camChangeOnDiff(camMinutesToMilliseconds(8)));
 	queue("setupCyborgsNorth", camChangeOnDiff(camMinutesToMilliseconds(10)));


### PR DESCRIPTION
Reverts the previous timer change for the dam hovers because I missed that the timer was in Seconds and not in Minutes.