### PR TITLE
Fix campaign video types in the intel menu

### DIFF
--- a/script/campaign/cam1-1.js
+++ b/script/campaign/cam1-1.js
@@ -138,8 +138,8 @@ function eventStartLevel()
 		},
 	});
 
-	camPlayVideos("FLIGHT");
-	hackAddMessage("C1-1_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER, true);
+	camPlayVideos({video: "FLIGHT", type: CAMP_MSG});
+	hackAddMessage("C1-1_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER, false);
 
 	queue("checkFrontBunkers", camSecondsToMilliseconds(5));
 }

--- a/script/campaign/cam1-1s.js
+++ b/script/campaign/cam1-1s.js
@@ -15,13 +15,13 @@ function eventChat(from, to, message)
 function resPowModVideo()
 {
 	powModVideoPlayed = true;
-	camPlayVideos("MB1_B2_MSG");
+	camPlayVideos({video: "MB1_B2_MSG", type: MISS_MSG});
 }
 
 //Sector clear commander!
 function secondVideo()
 {
-	camPlayVideos("SB1_1_MSG");
+	camPlayVideos({video: "SB1_1_MSG", type: MISS_MSG});
 }
 
 //Has player built the power module?

--- a/script/campaign/cam1-2.js
+++ b/script/campaign/cam1-2.js
@@ -11,7 +11,7 @@ const SCAVENGER_RES = [
 function exposeNorthBase()
 {
 	camDetectEnemyBase("NorthGroup"); // no problem if already detected
-	camPlayVideos("SB1_2_MSG2");
+	camPlayVideos({video: "SB1_2_MSG2", type: MISS_MSG});
 }
 
 function camArtifactPickup_ScavLab()

--- a/script/campaign/cam1-2s.js
+++ b/script/campaign/cam1-2s.js
@@ -7,6 +7,6 @@ function eventStartLevel()
 	centreView(13, 52);
 	setNoGoArea(10, 51, 12, 53, CAM_HUMAN_PLAYER);
 	setMissionTime(camChangeOnDiff(camMinutesToSeconds(30)));
-	camPlayVideos("SB1_2_MSG");
+	camPlayVideos({video: "SB1_2_MSG", type: CAMP_MSG});
 	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_1_2");
 }

--- a/script/campaign/cam1-3.js
+++ b/script/campaign/cam1-3.js
@@ -79,7 +79,7 @@ function enableNP(args)
 		repair: 66,
 	});
 
-	camPlayVideos(["pcv455.ogg", "SB1_3_MSG4"]);
+	camPlayVideos(["pcv455.ogg", {video: "SB1_3_MSG4", type: MISS_MSG}]);
 }
 
 function NPReinforce()
@@ -176,7 +176,7 @@ function camEnemyBaseEliminated_ScavBaseGroup()
 
 function playNPWarningMessage()
 {
-	camPlayVideos(["pcv455.ogg", "SB1_3_MSG3"]);
+	camPlayVideos(["pcv455.ogg", {video: "SB1_3_MSG3", type: CAMP_MSG}]);
 }
 
 function eventDroidBuilt(droid, structure)
@@ -226,7 +226,7 @@ function eventStartLevel()
 	camUpgradeOnMapTemplates(cTempl.trike, cTempl.trikeheavy, 7);
 	camUpgradeOnMapTemplates(cTempl.buggy, cTempl.buggyheavy, 7);
 	camUpgradeOnMapTemplates(cTempl.bjeep, cTempl.bjeepheavy, 7);
-	camUpgradeOnMapTemplates(cTempl.rbjeep, cTempl.rbjeep8, 7);	
+	camUpgradeOnMapTemplates(cTempl.rbjeep, cTempl.rbjeep8, 7);
 
 	camSetEnemyBases({
 		"ScavBaseGroup": {

--- a/script/campaign/cam1-3s.js
+++ b/script/campaign/cam1-3s.js
@@ -7,6 +7,6 @@ function eventStartLevel()
 	centreView(13, 52);
 	setNoGoArea(10, 51, 12, 53, CAM_HUMAN_PLAYER);
 	setMissionTime(camChangeOnDiff(camHoursToSeconds(1)));
-	camPlayVideos("SB1_3_UPDATE");
+	camPlayVideos({video: "SB1_3_UPDATE", type: CAMP_MSG});
 	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_1_3");
 }

--- a/script/campaign/cam1-4a.js
+++ b/script/campaign/cam1-4a.js
@@ -48,7 +48,7 @@ camAreaEvent("removeRedObjectiveBlip", function()
 
 camAreaEvent("LandingZoneTrigger", function()
 {
-	camPlayVideos(["pcv456.ogg", "SB1_4_B"]);
+	camPlayVideos(["pcv456.ogg", {video: "SB1_4_B", type: MISS_MSG}]);
 	hackRemoveMessage("C1-4_LZ", PROX_MSG, CAM_HUMAN_PLAYER); //Remove LZ 2 blip.
 
 	var lz = getObject("LandingZone2"); // will override later

--- a/script/campaign/cam1-4as.js
+++ b/script/campaign/cam1-4as.js
@@ -7,6 +7,6 @@ function eventStartLevel()
 	centreView(13, 52);
 	setNoGoArea(10, 51, 12, 53, CAM_HUMAN_PLAYER);
 	setMissionTime(camChangeOnDiff(camMinutesToSeconds(30)));
-	camPlayVideos("SB1_4_MSG");
+	camPlayVideos({video: "SB1_4_MSG", type: MISS_MSG});
 	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_1_4A");
 }

--- a/script/campaign/cam1-5s.js
+++ b/script/campaign/cam1-5s.js
@@ -6,6 +6,6 @@ function eventStartLevel()
 	centreView(13, 52);
 	setNoGoArea(10, 51, 12, 53, CAM_HUMAN_PLAYER);
 	setMissionTime(camChangeOnDiff(camHoursToSeconds(1)));
-	camPlayVideos("SB1_5_MSG");
+	camPlayVideos({video: "SB1_5_MSG", type: MISS_MSG});
 	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_1_5");
 }

--- a/script/campaign/cam1-7.js
+++ b/script/campaign/cam1-7.js
@@ -71,7 +71,7 @@ camAreaEvent("NPTransportTrigger", function(droid)
 //Only called once when the New Paradigm takes the artifact for the first time.
 function artifactVideoSetup()
 {
-	camPlayVideos("SB1_7_MSG3");
+	camPlayVideos({video: "SB1_7_MSG3", type: MISS_MSG});
 	camCallOnce("removeCanyonBlip");
 	artiMovePos = "NPWayPoint";
 }
@@ -163,7 +163,7 @@ function getArtifact()
 		if (camDist(artiMembers[idx], artiLoc) < GRAB_RADIUS)
 		{
 			camCallOnce("artifactVideoSetup");
-			hackAddMessage("C1-7_LZ2", PROX_MSG, CAM_HUMAN_PLAYER, true); //NPLZ blip
+			hackAddMessage("C1-7_LZ2", PROX_MSG, CAM_HUMAN_PLAYER, false); //NPLZ blip
 			droidWithArtiID = artiMembers[idx].id;
 			enemyHasArtifact = true;
 			camSafeRemoveObject(realCrate, false);
@@ -279,7 +279,7 @@ function eventStartLevel()
 	camUpgradeOnMapTemplates(cTempl.buggy, cTempl.buggyheavy, SCAV_7);
 	camUpgradeOnMapTemplates(cTempl.bjeep, cTempl.bjeepheavy, SCAV_7);
 	camUpgradeOnMapTemplates(cTempl.rbjeep, cTempl.rbjeep8, SCAV_7);
-	
+
 	// New MRA Mantis Tracks units on the hill
 	addDroid(NEW_PARADIGM, 29, 16, "MRA Mantis Tracks", "Body12SUP", "tracked01", "", "", "Rocket-MRL");
 	addDroid(NEW_PARADIGM, 29, 17, "MRA Mantis Tracks", "Body12SUP", "tracked01", "", "", "Rocket-MRL");
@@ -347,6 +347,6 @@ function eventStartLevel()
 	camManageTrucks(NEW_PARADIGM);
 	buildLancers();
 
-	hackAddMessage("C1-7_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER, true); //Canyon
+	hackAddMessage("C1-7_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER, false); //Canyon
 	queue("startArtifactCollection", camChangeOnDiff(camMinutesToMilliseconds(1.5)));
 }

--- a/script/campaign/cam1-7s.js
+++ b/script/campaign/cam1-7s.js
@@ -6,6 +6,6 @@ function eventStartLevel()
 	centreView(13, 52);
 	setNoGoArea(10, 51, 12, 53, CAM_HUMAN_PLAYER);
 	setMissionTime(camChangeOnDiff(camMinutesToSeconds(30)));
-	camPlayVideos(["SB1_7_MSG", "SB1_7_MSG2"]);
+	camPlayVideos([{video: "SB1_7_MSG", type: CAMP_MSG}, {video: "SB1_7_MSG2", type: MISS_MSG}]);
 	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_1_7");
 }

--- a/script/campaign/cam1-d.js
+++ b/script/campaign/cam1-d.js
@@ -276,7 +276,7 @@ function eventStartLevel()
 		},
 	});
 
-	hackAddMessage("C1D_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER, true);
+	hackAddMessage("C1D_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER, false);
 
 	queue("setupPatrols", camMinutesToMilliseconds(2.5));
 }

--- a/script/campaign/cam1-ds.js
+++ b/script/campaign/cam1-ds.js
@@ -6,6 +6,6 @@ function eventStartLevel()
 	centreView(13, 52);
 	setNoGoArea(10, 51, 12, 53, CAM_HUMAN_PLAYER);
 	setMissionTime(camChangeOnDiff(camHoursToSeconds(2)));
-	camPlayVideos(["MB1D_MSG", "MB1D_MSG2"]);
+	camPlayVideos([{video: "MB1D_MSG", type: CAMP_MSG}, {video: "MB1D_MSG2", type: MISS_MSG}]);
 	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_1_D");
 }

--- a/script/campaign/cam1a-c.js
+++ b/script/campaign/cam1a-c.js
@@ -158,7 +158,7 @@ function eventStartLevel()
 	}
 
 	camCompleteRequiredResearch(NEW_PARADIGM_RES, NEW_PARADIGM);
-	camPlayVideos(["MB1A-C_MSG", "MB1A-C_MSG2"]);
+	camPlayVideos([{video: "MB1A-C_MSG", type: CAMP_MSG}, {video: "MB1A-C_MSG2", type: MISS_MSG}]);
 
 	index = 0;
 	switchLZ = 0;

--- a/script/campaign/cam1a.js
+++ b/script/campaign/cam1a.js
@@ -12,7 +12,7 @@ const SCAVENGER_RES = [
 // Player zero's droid enters area next to first oil patch.
 camAreaEvent("launchScavAttack", function(droid)
 {
-	camPlayVideos(["pcv456.ogg", "MB1A_MSG"]);
+	camPlayVideos(["pcv456.ogg", {video: "MB1A_MSG", type: MISS_MSG}]);
 	hackAddMessage("C1A_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER, false);
 	// Send scavengers on war path if triggered above.
 	camManageGroup(camMakeGroup("scavAttack1", ENEMIES), CAM_ORDER_ATTACK, {
@@ -161,7 +161,7 @@ function eventStartLevel()
 	camCompleteRequiredResearch(SCAVENGER_RES, 7);
 
 	// Give player briefing.
-	hackAddMessage("CMB1_MSG", CAMP_MSG, CAM_HUMAN_PLAYER, false);
+	camPlayVideos({video: "CMB1_MSG", type: CAMP_MSG, immediate: false});
 	if (difficulty === HARD)
 	{
 		setMissionTime(camMinutesToSeconds(40));

--- a/script/campaign/cam1b.js
+++ b/script/campaign/cam1b.js
@@ -120,7 +120,7 @@ function eventStartLevel()
 		},
 	});
 
-	camPlayVideos("MB1B_MSG");
+	camPlayVideos({video: "MB1B_MSG", type: MISS_MSG});
 	camDetectEnemyBase("base4group"); // power surge detected
 
 	camSetFactories({

--- a/script/campaign/cam1c.js
+++ b/script/campaign/cam1c.js
@@ -140,7 +140,7 @@ camAreaEvent("NPLZ1Trigger", function()
 {
 	// Message4 here, Message3 for the second LZ, and
 	// please don't ask me why they did it this way
-	camPlayVideos("MB1C4_MSG");
+	camPlayVideos({video: "MB1C4_MSG", type: MISS_MSG});
 	camDetectEnemyBase("NPLZ1Group");
 
 	camSetBaseReinforcements("NPLZ1Group", camChangeOnDiff(camMinutesToMilliseconds(5)), "getDroidsForNPLZ",
@@ -153,7 +153,7 @@ camAreaEvent("NPLZ1Trigger", function()
 
 camAreaEvent("NPLZ2Trigger", function()
 {
-	camPlayVideos("MB1C3_MSG");
+	camPlayVideos({video: "MB1C3_MSG", type: MISS_MSG});
 	camDetectEnemyBase("NPLZ2Group");
 
 	camSetBaseReinforcements("NPLZ2Group", camChangeOnDiff(camMinutesToMilliseconds(5)), "getDroidsForNPLZ",
@@ -276,7 +276,7 @@ function eventStartLevel()
 	});
 
 	hackAddMessage("C1C_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER, false); // initial beacon
-	camPlayVideos(["MB1C_MSG", "MB1C2_MSG"]);
+	camPlayVideos([{video: "MB1C_MSG", type: CAMP_MSG}, {video: "MB1C2_MSG", type: CAMP_MSG}]);
 
 	camSetArtifacts({
 		"ScavSouthFactory": { tech: ["R-Wpn-Rocket05-MiniPod", "R-Wpn-Cannon2Mk1"] },

--- a/script/campaign/cam1ca.js
+++ b/script/campaign/cam1ca.js
@@ -157,7 +157,7 @@ function eventStartLevel()
 	}
 
 	setMissionTime(camChangeOnDiff(camMinutesToSeconds(30)));
-	camPlayVideos("MB1CA_MSG");
+	camPlayVideos({video: "MB1CA_MSG", type: CAMP_MSG});
 
 	// first transport after 10 seconds
 	queue("startTransporterAttack", camSecondsToMilliseconds(10));

--- a/script/campaign/cam1end.js
+++ b/script/campaign/cam1end.js
@@ -6,6 +6,6 @@ function eventStartLevel()
 	centreView(13, 52);
 	setNoGoArea(10, 51, 12, 53, CAM_HUMAN_PLAYER);
 	setMissionTime(camMinutesToSeconds(15));
-	camPlayVideos(["CAM1_OUT", "CAM1_OUT2", "CAM2_BRIEF"]);
+	camPlayVideos([{video: "CAM1_OUT", type: CAMP_MSG}, {video: "CAM1_OUT2", type: CAMP_MSG}, {video: "CAM2_BRIEF", type: CAMP_MSG}]);
 	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "CAM_2A");
 }

--- a/script/campaign/cam2-1s.js
+++ b/script/campaign/cam2-1s.js
@@ -18,5 +18,5 @@ function eventStartLevel()
 	//Set Mission Time
 	setMissionTime(camChangeOnDiff(camMinutesToSeconds(30)));
 	//Give player briefings
-	camPlayVideos(["MB2_1_MSG", "MB2_1_MSG2"]);
+	camPlayVideos([{video: "MB2_1_MSG", type: CAMP_MSG}, {video: "MB2_1_MSG2", type: MISS_MSG}]);
 }

--- a/script/campaign/cam2-1x.js
+++ b/script/campaign/cam2-1x.js
@@ -130,7 +130,7 @@ function eventStartLevel()
 	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, THE_COLLECTIVE);
 
 	//Add crash site blip and from an alliance with the crashed team.
-	hackAddMessage("C21_OBJECTIVE", PROX_MSG, CAM_HUMAN_PLAYER, true);
+	hackAddMessage("C21_OBJECTIVE", PROX_MSG, CAM_HUMAN_PLAYER, false);
 	setAlliance(CAM_HUMAN_PLAYER, TRANSPORT_TEAM, true);
 
 	//set downed transport team colour to be Project Green.

--- a/script/campaign/cam2-2.js
+++ b/script/campaign/cam2-2.js
@@ -226,7 +226,7 @@ function eventStartLevel()
 	truckDefense();
 	camEnableFactory("COFactoryWest");
 
-	hackAddMessage("C22_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER, true);
+	hackAddMessage("C22_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER, false);
 
 	queue("vtolAttack", camSecondsToMilliseconds(1));
 	setTimer("truckDefense", camChangeOnDiff(camMinutesToMilliseconds(3)));

--- a/script/campaign/cam2-2s.js
+++ b/script/campaign/cam2-2s.js
@@ -7,6 +7,6 @@ function eventStartLevel()
     setNoGoArea(86, 99, 88, 101, CAM_HUMAN_PLAYER);
     setNoGoArea(49, 83, 51, 85, THE_COLLECTIVE);
     setMissionTime(camChangeOnDiff(camMinutesToSeconds(70)));
-    camPlayVideos(["MB2_2_MSG", "MB2_2_MSG2", "MB2_2_MSG3"]);
+    camPlayVideos([{video: "MB2_2_MSG", type: CAMP_MSG}, {video:"MB2_2_MSG2", type: CAMP_MSG}, {video: "MB2_2_MSG3", type: MISS_MSG}]);
     camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_2_2");
 }

--- a/script/campaign/cam2-5.js
+++ b/script/campaign/cam2-5.js
@@ -171,7 +171,7 @@ function eventStartLevel()
 		},
 	});
 
-	hackAddMessage("C25_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER, true);
+	hackAddMessage("C25_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER, false);
 
 	queue("setupDamHovers", camSecondsToMilliseconds(3));
 	queue("setupCyborgsEast", camChangeOnDiff(camMinutesToMilliseconds(3)));

--- a/script/campaign/cam2-5s.js
+++ b/script/campaign/cam2-5s.js
@@ -7,6 +7,6 @@ function eventStartLevel()
     setNoGoArea(86, 99, 88, 101, CAM_HUMAN_PLAYER);
     setNoGoArea(49, 83, 51, 85, THE_COLLECTIVE);
     setMissionTime(camChangeOnDiff(camHoursToSeconds(1)));
-    camPlayVideos(["MB2_5_MSG", "MB2_5_MSG2"]);
+    camPlayVideos([{video: "MB2_5_MSG", type: CAMP_MSG}, {video: "MB2_5_MSG2", type: MISS_MSG}]);
     camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_2_5");
 }

--- a/script/campaign/cam2-6.js
+++ b/script/campaign/cam2-6.js
@@ -232,8 +232,8 @@ function eventStartLevel()
 		},
 	});
 
-	hackAddMessage("C26_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER, true);
-	
+	hackAddMessage("C26_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER, false);
+
 	if (difficulty >= HARD)
 	{
 		addDroid(THE_COLLECTIVE, 26, 27, "Truck Panther Tracks", "Body6SUPP", "tracked01", "", "", "Spade1Mk1");

--- a/script/campaign/cam2-6s.js
+++ b/script/campaign/cam2-6s.js
@@ -7,6 +7,6 @@ function eventStartLevel()
     setNoGoArea(86, 99, 88, 101, CAM_HUMAN_PLAYER);
     setNoGoArea(49, 83, 51, 85, THE_COLLECTIVE);
     setMissionTime(camChangeOnDiff(camHoursToSeconds(1)));
-    camPlayVideos(["MB2_6_MSG", "MB2_6_MSG2", "MB2_6_MSG3"]);
+    camPlayVideos([{video: "MB2_6_MSG", type: CAMP_MSG}, {video: "MB2_6_MSG2", type: CAMP_MSG}, {video: "MB2_6_MSG3", type: MISS_MSG}]);
     camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_2_6");
 }

--- a/script/campaign/cam2-7.js
+++ b/script/campaign/cam2-7.js
@@ -230,10 +230,10 @@ function eventStartLevel()
 	//This mission shows you the approximate base locations at the start.
 	//These are removed once the base it is close to is seen and is replaced
 	//with a more precise proximity blip.
-	hackAddMessage("C27_OBJECTIVE1", PROX_MSG, CAM_HUMAN_PLAYER, true);
-	hackAddMessage("C27_OBJECTIVE2", PROX_MSG, CAM_HUMAN_PLAYER, true);
-	hackAddMessage("C27_OBJECTIVE3", PROX_MSG, CAM_HUMAN_PLAYER, true);
-	hackAddMessage("C27_OBJECTIVE4", PROX_MSG, CAM_HUMAN_PLAYER, true);
+	hackAddMessage("C27_OBJECTIVE1", PROX_MSG, CAM_HUMAN_PLAYER, false);
+	hackAddMessage("C27_OBJECTIVE2", PROX_MSG, CAM_HUMAN_PLAYER, false);
+	hackAddMessage("C27_OBJECTIVE3", PROX_MSG, CAM_HUMAN_PLAYER, false);
+	hackAddMessage("C27_OBJECTIVE4", PROX_MSG, CAM_HUMAN_PLAYER, false);
 
 	if (difficulty >= HARD)
 	{

--- a/script/campaign/cam2-7s.js
+++ b/script/campaign/cam2-7s.js
@@ -7,6 +7,6 @@ function eventStartLevel()
     setNoGoArea(86, 99, 88, 101, CAM_HUMAN_PLAYER);
     setNoGoArea(49, 83, 51, 85, THE_COLLECTIVE);
     setMissionTime(camChangeOnDiff(camHoursToSeconds(1.5)));
-    camPlayVideos(["MB2_7_MSG", "MB2_7_MSG2"]);
+    camPlayVideos([{video: "MB2_7_MSG", type: CAMP_MSG}, {video: "MB2_7_MSG2", type: MISS_MSG}]);
     camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_2_7");
 }

--- a/script/campaign/cam2-8s.js
+++ b/script/campaign/cam2-8s.js
@@ -7,6 +7,6 @@ function eventStartLevel()
     setNoGoArea(86, 99, 88, 101, CAM_HUMAN_PLAYER);
     setNoGoArea(49, 83, 51, 85, THE_COLLECTIVE);
     setMissionTime(camChangeOnDiff(camHoursToSeconds(1)));
-    camPlayVideos(["MB2_8_MSG", "MB2_8_MSG2"]);
+    camPlayVideos([{video: "MB2_8_MSG", type: CAMP_MSG}, {video: "MB2_8_MSG2", type: MISS_MSG}]);
     camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_2_8");
 }

--- a/script/campaign/cam2-a.js
+++ b/script/campaign/cam2-a.js
@@ -16,7 +16,7 @@ camAreaEvent("vtolRemoveZone", function(droid)
 //Attack and destroy all those who resist the Machine! -The Collective
 function secondVideo()
 {
-	camPlayVideos("MB2A_MSG2");
+	camPlayVideos({video: "MB2A_MSG2", type: CAMP_MSG});
 }
 
 //Damage the base and droids for the player
@@ -336,7 +336,7 @@ function eventStartLevel()
 	camManageTrucks(THE_COLLECTIVE);
 	truckDefense();
 	setUnitRank(); //All pre-placed player droids are ranked.
-	camPlayVideos("MB2A_MSG");
+	camPlayVideos({video: "MB2A_MSG", type: MISS_MSG});
 	startedFromMenu = false;
 
 	//Only if starting Beta directly rather than going through Alpha

--- a/script/campaign/cam2-b.js
+++ b/script/campaign/cam2-b.js
@@ -125,7 +125,7 @@ function eventStartLevel()
 	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, THE_COLLECTIVE);
 
 	setMissionTime(camChangeOnDiff(camHoursToSeconds(2)));
-	camPlayVideos(["MB2_B_MSG", "MB2_B_MSG2"]);
+	camPlayVideos([{video: "MB2_B_MSG", type: CAMP_MSG}, {video: "MB2_B_MSG2", type: MISS_MSG}]);
 
 	camSetArtifacts({
 		"COResearchLab": { tech: "R-Wpn-Flame2" },
@@ -241,7 +241,7 @@ function eventStartLevel()
 
 	camManageTrucks(THE_COLLECTIVE);
 	truckDefense();
-	hackAddMessage("C2B_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER, true);
+	hackAddMessage("C2B_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER, false);
 
 	camEnableFactory("COHeavyFac-b4");
 	camEnableFactory("COCybFac-b4");

--- a/script/campaign/cam2-c.js
+++ b/script/campaign/cam2-c.js
@@ -31,8 +31,8 @@ function videoTrigger()
 	setTimer("captureCivilians", camChangeOnDiff(camSecondsToMilliseconds(10)));
 
 	hackRemoveMessage("C2C_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER);
-	camPlayVideos("MB2_C_MSG2");
-	hackAddMessage("C2C_OBJ2", PROX_MSG, CAM_HUMAN_PLAYER, true);
+	camPlayVideos({video: "MB2_C_MSG2", type: MISS_MSG});
+	hackAddMessage("C2C_OBJ2", PROX_MSG, CAM_HUMAN_PLAYER, false);
 }
 
 //Enable heavy factories and make groups do what they need to.
@@ -404,8 +404,8 @@ function eventStartLevel()
 	shepardGroup = camMakeGroup("heavyGroup2");
 	enableFactories();
 
-	camPlayVideos("MB2_C_MSG");
-	hackAddMessage("C2C_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER, true);
+	camPlayVideos({video: "MB2_C_MSG", type: MISS_MSG});
+	hackAddMessage("C2C_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER, false);
 
 	queue("activateGroups", camChangeOnDiff(camMinutesToMilliseconds(8)));
 	setTimer("truckDefense", camChangeOnDiff(camMinutesToMilliseconds(3)));

--- a/script/campaign/cam2-d.js
+++ b/script/campaign/cam2-d.js
@@ -145,7 +145,7 @@ function eventStartLevel()
 
 	camManageTrucks(THE_COLLECTIVE);
 	truckDefense();
-	hackAddMessage("C2D_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER, true);
+	hackAddMessage("C2D_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER, false);
 
 	camEnableFactory("COHeavyFactory");
 	camEnableFactory("COSouthCyborgFactory");

--- a/script/campaign/cam2-ds.js
+++ b/script/campaign/cam2-ds.js
@@ -8,6 +8,6 @@ function eventStartLevel()
     setNoGoArea(86, 99, 88, 101, CAM_HUMAN_PLAYER);
     setNoGoArea(49, 83, 51, 85, THE_COLLECTIVE);
     setMissionTime(camChangeOnDiff(camMinutesToSeconds(75)));
-    camPlayVideos(["MB2_DI_MSG", "MB2_DI_MSG2"]);
+    camPlayVideos([{video: "MB2_DI_MSG", type: MISS_MSG}, {video: "MB2_DI_MSG2", type: CAMP_MSG}]);
     camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_2D");
 }

--- a/script/campaign/cam2-end.js
+++ b/script/campaign/cam2-end.js
@@ -45,7 +45,7 @@ function playLastVideo()
 	{
 		camSafeRemoveObject(droids[i], false);
 	}
-	camPlayVideos("CAM2_OUT");
+	camPlayVideos({video: "CAM2_OUT", type: CAMP_MSG});
 }
 
 //Allow a win if a transporter was launched with a construction droid.
@@ -207,7 +207,7 @@ function eventStartLevel()
 	camCompleteRequiredResearch(COLLECTIVE_RES, THE_COLLECTIVE);
 
 	allowWin = false;
-	camPlayVideos(["MB2_DII_MSG", "MB2_DII_MSG2"]);
+	camPlayVideos([{video: "MB2_DII_MSG", type: CAMP_MSG}, {video: "MB2_DII_MSG2", type: MISS_MSG}]);
 
 	vtolAttack();
 	if (difficulty === INSANE)

--- a/script/campaign/cam3-1.js
+++ b/script/campaign/cam3-1.js
@@ -164,7 +164,7 @@ function setupNextMission()
 	{
 		camSetExtraObjectiveMessage(_("Move all units into the valley"));
 
-		camPlayVideos(["labort.ogg", "MB3_1B_MSG", "MB3_1B_MSG2"]);
+		camPlayVideos(["labort.ogg", {video: "MB3_1B_MSG", type: CAMP_MSG}, {video: "MB3_1B_MSG2", type: MISS_MSG}]);
 
 		setScrollLimits(0, 0, 64, 64); //Reveal the whole map.
 		setMissionTime(camChangeOnDiff(camMinutesToSeconds(30)));

--- a/script/campaign/cam3-1s.js
+++ b/script/campaign/cam3-1s.js
@@ -7,6 +7,6 @@ function eventStartLevel()
 	setNoGoArea(55, 119, 57, 121, CAM_HUMAN_PLAYER);
 	setNoGoArea(7, 52, 9, 54, NEXUS);
 	setMissionTime(camChangeOnDiff(camMinutesToSeconds(75)));
-	camPlayVideos(["MB3_1A_MSG", "MB3_1A_MSG2"]);
+	camPlayVideos([{video: "MB3_1A_MSG", type: CAMP_MSG}, {video: "MB3_1A_MSG2", type: MISS_MSG}]);
 	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_3_1");
 }

--- a/script/campaign/cam3-2.js
+++ b/script/campaign/cam3-2.js
@@ -54,14 +54,14 @@ camAreaEvent("rescueTrigger", function(droid)
 	queue("getAlphaUnitIDs", camSecondsToMilliseconds(2));
 	setTimer("phantomFactorySE", camChangeOnDiff(camMinutesToMilliseconds(4)));
 
-	camPlayVideos("MB3_2_MSG4");
+	camPlayVideos({video: "MB3_2_MSG4", type: MISS_MSG});
 });
 
 //Play videos, donate alpha to the player and setup reinforcements.
 camAreaEvent("phantomFacTrigger", function(droid)
 {
 	vtolAttack();
-	camPlayVideos(["pcv456.ogg", "MB3_2_MSG3"]); //Warn about VTOLs.
+	camPlayVideos(["pcv456.ogg", {video: "MB3_2_MSG3", type: CAMP_MSG}]); //Warn about VTOLs.
 	queue("enableReinforcements", camSecondsToMilliseconds(5));
 });
 

--- a/script/campaign/cam3-2s.js
+++ b/script/campaign/cam3-2s.js
@@ -6,7 +6,7 @@ function eventStartLevel()
 	centreView(57, 119);
 	setNoGoArea(55, 119, 57, 121, CAM_HUMAN_PLAYER);
 	setNoGoArea(7, 52, 9, 54, NEXUS);
-	setMissionTime(camChangeOnDiff(camHoursToSeconds(1))); 
-	camPlayVideos(["MB3_2_MSG", "MB3_2_MSG2"]);
+	setMissionTime(camChangeOnDiff(camHoursToSeconds(1)));
+	camPlayVideos([{video: "MB3_2_MSG", type: CAMP_MSG}, {video: "MB3_2_MSG2", type: MISS_MSG}]);
 	camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "SUB_3_2");
 }

--- a/script/campaign/cam3-4.js
+++ b/script/campaign/cam3-4.js
@@ -28,7 +28,7 @@ function eventDestroyed(obj)
 		if (enumDroid(CAM_HUMAN_PLAYER).length === 0)
 		{
 			//Play an addition special video when losing on the last Gamma mission.
-			hackAddMessage("MB3_4_MSG5", MISS_MSG, CAM_HUMAN_PLAYER, true);
+			camPlayVideos({video: "MB3_4_MSG5", type: CAMP_MSG});
 		}
 	}
 }
@@ -86,7 +86,7 @@ function activateNexus()
 
 function camEnemyBaseDetected_NX_SWBase()
 {
-	hackAddMessage("MB3_4_MSG4", MISS_MSG, CAM_HUMAN_PLAYER, true);
+	camPlayVideos({video: "MB3_4_MSG4", type: MISS_MSG});
 	firstAbsorbAttack(); //before Nexus state activation to prevent sound spam.
 	queue("activateNexus", camSecondsToMilliseconds(1));
 }
@@ -386,7 +386,7 @@ function eventStartLevel()
 	});
 
 	//Show Project transport flying video.
-	hackAddMessage("MB3_4_MSG3", MISS_MSG, CAM_HUMAN_PLAYER, true);
+	camPlayVideos({video: "MB3_4_MSG3", type: CAMP_MSG});
 	hackAddMessage("CM34_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER);
 
 	queue("enableAllFactories", camChangeOnDiff(camMinutesToMilliseconds(5)));

--- a/script/campaign/cam3-4s.js
+++ b/script/campaign/cam3-4s.js
@@ -9,6 +9,6 @@ function eventStartLevel()
      setScrollLimits(0, 137, 64, 256);
      setMissionTime(camMinutesToSeconds(30));
      setPower(playerPower(CAM_HUMAN_PLAYER) + 50000, CAM_HUMAN_PLAYER);
-     camPlayVideos(["MB3_4_MSG", "MB3_4_MSG2"]);
+     camPlayVideos([{video: "MB3_4_MSG", type: CAMP_MSG}, {video: "MB3_4_MSG2", type: MISS_MSG}]);
      camSetStandardWinLossConditions(CAM_VICTORY_PRE_OFFWORLD, "CAM_3_4");
 }

--- a/script/campaign/cam3-a.js
+++ b/script/campaign/cam3-a.js
@@ -352,7 +352,7 @@ function eventStartLevel()
 		setTimer("truckDefense", camChangeOnDiff(camMinutesToMilliseconds(4.5)));
 	}
 
-	camPlayVideos(["CAM3_INT", "MB3A_MSG2"]);
+	camPlayVideos([{video: "CAM3_INT", type: CAMP_MSG}, {video: "MB3A_MSG2", type: MISS_MSG}]);
 	startedFromMenu = false;
 	truckLocCounter = 0;
 

--- a/script/campaign/cam3-ab.js
+++ b/script/campaign/cam3-ab.js
@@ -247,7 +247,7 @@ function eventStartLevel()
 	});
 
 	camSetNexusState(true);
-	camPlayVideos(["MB3_AB_MSG", "MB3_AB_MSG2", "MB3_AB_MSG3"]);
+	camPlayVideos([{video: "MB3_AB_MSG", type: CAMP_MSG}, {video: "MB3_AB_MSG2", type: CAMP_MSG}, {video: "MB3_AB_MSG3", type: MISS_MSG}]);
 
 	centreView(startpos.x, startpos.y);
 	setNoGoArea(lz.x, lz.y, lz.x2, lz.y2, CAM_HUMAN_PLAYER);

--- a/script/campaign/cam3-ad1.js
+++ b/script/campaign/cam3-ad1.js
@@ -318,7 +318,7 @@ function eventStartLevel()
 		},
 	});
 
-	camPlayVideos(["MB3_AD1_MSG", "MB3_AD1_MSG2", "MB3_AD1_MSG3"]);
+	camPlayVideos([{video: "MB3_AD1_MSG", type: CAMP_MSG}, {video: "MB3_AD1_MSG2", type: CAMP_MSG}, {video: "MB3_AD1_MSG3", type: MISS_MSG}]);
 	hackAddMessage("CM3D1_OBJ1", PROX_MSG, CAM_HUMAN_PLAYER);
 	camEnableFactory("NXbase1VtolFacArti");
 	camEnableFactory("NXcyborgFac1");

--- a/script/campaign/cam3-ad2.js
+++ b/script/campaign/cam3-ad2.js
@@ -231,7 +231,7 @@ function eventResearched(research, structure, player)
 		if (research.name === videoInfo[i].res && !videoInfo[i].played)
 		{
 			videoInfo[i].played = true;
-			camPlayVideos(videoInfo[i].video);
+			camPlayVideos({video: videoInfo[i].video, type: videoInfo[i].type});
 			if (videoInfo[i].res === "R-Sys-Resistance")
 			{
 				enableResearch("R-Comp-MissileCodes01", CAM_HUMAN_PLAYER);
@@ -249,7 +249,7 @@ function checkTime()
 {
 	if (getMissionTime() <= 2)
 	{
-		camPlayVideos("MB3_AD2_MSG2");
+		camPlayVideos({video: "MB3_AD2_MSG2", type: CAMP_MSG});
 		setMissionTime(camHoursToSeconds(1));
 
 		phantomFactorySpawn();
@@ -284,10 +284,10 @@ function eventStartLevel()
 	mapLimit = 137.0;
 	winFlag = false;
 	videoInfo = [
-		{played: false, video: "MB3_AD2_MSG3", res: "R-Sys-Resistance"},
-		{played: false, video: "MB3_AD2_MSG4", res: "R-Comp-MissileCodes01"},
-		{played: false, video: "MB3_AD2_MSG5", res: "R-Comp-MissileCodes02"},
-		{played: false, video: "MB3_AD2_MSG6", res: "R-Comp-MissileCodes03"},
+		{played: false, video: "MB3_AD2_MSG3", type: MISS_MSG, res: "R-Sys-Resistance"},
+		{played: false, video: "MB3_AD2_MSG4", type: CAMP_MSG, res: "R-Comp-MissileCodes01"},
+		{played: false, video: "MB3_AD2_MSG5", type: CAMP_MSG, res: "R-Comp-MissileCodes02"},
+		{played: false, video: "MB3_AD2_MSG6", type: CAMP_MSG, res: "R-Comp-MissileCodes03"},
 	];
 
 	camSetStandardWinLossConditions(CAM_VICTORY_STANDARD, "CAM_3_4S", {
@@ -312,7 +312,7 @@ function eventStartLevel()
 	setNoGoArea(enemyLz.x, enemyLz.y, enemyLz.x2, enemyLz.y2, NEXUS);
 
 	camCompleteRequiredResearch(NEXUS_RES, NEXUS);
-	camPlayVideos("MB3_AD2_MSG");
+	camPlayVideos({video: "MB3_AD2_MSG", type: MISS_MSG});
 
 	setTimer("checkTime", camSecondsToMilliseconds(0.2));
 	queue("vtolAttack", camChangeOnDiff(camMinutesToMilliseconds(3)));

--- a/script/campaign/cam3-b.js
+++ b/script/campaign/cam3-b.js
@@ -228,7 +228,7 @@ function trapSprung()
 {
 	setAlliance(GAMMA, NEXUS, true);
 	setAlliance(GAMMA, CAM_HUMAN_PLAYER, false);
-	camPlayVideos("MB3_B_MSG3");
+	camPlayVideos({video: "MB3_B_MSG3", type: CAMP_MSG});
 	hackRemoveMessage("CM3B_GAMMABASE", PROX_MSG, CAM_HUMAN_PLAYER);
 
 	setMissionTime(camChangeOnDiff(camMinutesToSeconds(90)));
@@ -357,8 +357,8 @@ function eventStartLevel()
 	}
 
 	setAlliance(GAMMA, CAM_HUMAN_PLAYER, true);
-	hackAddMessage("CM3B_GAMMABASE", PROX_MSG, CAM_HUMAN_PLAYER, true);
-	camPlayVideos(["MB3_B_MSG", "MB3_B_MSG2"]);
+	hackAddMessage("CM3B_GAMMABASE", PROX_MSG, CAM_HUMAN_PLAYER, false);
+	camPlayVideos([{video: "MB3_B_MSG", type: CAMP_MSG}, {video: "MB3_B_MSG2", type: MISS_MSG}]);
 
 	changePlayerColour(GAMMA, 0);
 	setAlliance(GAMMA, CAM_HUMAN_PLAYER, true);

--- a/script/campaign/cam3-c.js
+++ b/script/campaign/cam3-c.js
@@ -161,8 +161,8 @@ function eventStartLevel()
 
 	camCompleteRequiredResearch(NEXUS_RES, NEXUS);
 	camCompleteRequiredResearch(GAMMA_ALLY_RES, GAMMA);
-	hackAddMessage("CM3C_GAMMABASE", PROX_MSG, CAM_HUMAN_PLAYER, true);
-	hackAddMessage("CM3C_BETATEAM", PROX_MSG, CAM_HUMAN_PLAYER, true);
+	hackAddMessage("CM3C_GAMMABASE", PROX_MSG, CAM_HUMAN_PLAYER, false);
+	hackAddMessage("CM3C_BETATEAM", PROX_MSG, CAM_HUMAN_PLAYER, false);
 
 	setAlliance(CAM_HUMAN_PLAYER, GAMMA, true);
 	setAlliance(NEXUS, GAMMA, true);
@@ -246,7 +246,7 @@ function eventStartLevel()
 		},
 	});
 
-	camPlayVideos(["MB3_C_MSG", "MB3_C_MSG2"]);
+	camPlayVideos([{video: "MB3_C_MSG", type: CAMP_MSG}, {video: "MB3_C_MSG2", type: MISS_MSG}]);
 	setScrollLimits(0, 137, 64, 192); //Show the middle section of the map.
 	changePlayerColour(GAMMA, 0);
 

--- a/script/campaign/libcampaign_includes/video.js
+++ b/script/campaign/libcampaign_includes/video.js
@@ -6,29 +6,44 @@
 // Be aware that eventVideoDone will be triggered for each video
 // and will be received by the mission script's eventVideoDone, should it exist.
 
-//;; ## camPlayVideos(videos)
+//;; ## camPlayVideos(obj)
 //;;
+//;; Formats for parameter obj: {video: "video string", type: MISS_MSG/CAMP_MSG, immediate: true/false} OR
+//;; ["sound file", {video: "video string", type: MISS_MSG/CAMP_MSG, immediate: true/false}, ...]
+//;; object property "immediate" is optional since most videos are immediate.
 //;; If videos is an array, queue up all of them for immediate playing. This
 //;; function will play one video sequence should one be provided. Also,
 //;; should a sound file be in a string (pcvX.ogg)  __camEnqueueVideos() will recognize it
-//;; as a sound to play before a video. Of which is only supported when passed as
-//;; an array.
+//;; as a sound to play before a video. Of which is only supported when parameter obj is an array.
 //;;
-function camPlayVideos(videos)
+function camPlayVideos(obj)
 {
-	if (videos instanceof Array)
+	if (obj instanceof Array)
 	{
-		__camVideoSequences = videos;
+		__camVideoSequences = obj;
 		__camEnqueueVideos();
+	}
+	else if (obj instanceof Object)
+	{
+		if (!camDef(obj.video) || !camIsString(obj.video))
+		{
+			camDebug("Problem with video property.");
+			return;
+		}
+		if (!camDef(obj.type) || (obj.type !== MISS_MSG && obj.type !== CAMP_MSG))
+		{
+			camDebug("Video message type was NOT specified. Please specify one.")
+			return;
+		}
+		if (!camDef(obj.immediate))
+		{
+			obj.immediate = true;
+		}
+		hackAddMessage(obj.video, obj.type, CAM_HUMAN_PLAYER, obj.immediate);
 	}
 	else
 	{
-		if (!camIsString(videos))
-		{
-			camDebug("Non string passed in to play a video. Skipping.");
-			return;
-		}
-		hackAddMessage(videos, MISS_MSG, CAM_HUMAN_PLAYER, true);
+		camDebug("Funky camPlayVideos() parameter!");
 	}
 }
 
@@ -46,21 +61,39 @@ function __camEnqueueVideos()
 	const SOUND_IDENTIFER = ".ogg";
 	var what = __camVideoSequences[0];
 
-	if (!camIsString(what))
-	{
-		camDebug("Non string found in __camVideoSequences. Stopping playback.");
-		return;
-	}
-
 	// Check if this is a sound to play before some sequence.
-	if (what.indexOf(SOUND_IDENTIFER) !== -1)
+	if (typeof what === "string" && what.indexOf(SOUND_IDENTIFER) !== -1)
 	{
 		playSound(what);
 		queue("__camEnqueueVideos", camSecondsToMilliseconds(3.2)); //more than enough for most sounds.
 	}
+	else if (typeof what === "object")
+	{
+		var play = true;
+
+		if (!camDef(what.video) || !camIsString(what.video))
+		{
+			camDebug("Problem with video property.");
+			play = false;
+		}
+		if (!camDef(what.type) || (what.type !== MISS_MSG && what.type !== CAMP_MSG))
+		{
+			camDebug("Video message type was NOT specified. Please specify one.")
+			play = false;
+		}
+		if (!camDef(what.immediate))
+		{
+			what.immediate = true;
+		}
+
+		if (play)
+		{
+			hackAddMessage(what.video, what.type, CAM_HUMAN_PLAYER, what.immediate);
+		}
+	}
 	else
 	{
-		hackAddMessage(what, MISS_MSG, CAM_HUMAN_PLAYER, true);
+		camDebug("Funky camPlayVideos() parameter!");
 	}
 
 	__camVideoSequences.shift();


### PR DESCRIPTION
Replaces the format of camPlayVideos() with something much better. Also set the `immediate` argument with `hackAddMessage` on proximity blips to false since they can't be displayed as a video.

`camPlayVideos({video: "VIDEO_STRING", type: CAMP_MSG/MISS_MSG});` or
`camPlayVideos(["soundFile.ogg", {video: "VIDEO_STRING", type: CAMP_MSG/MISS_MSG}, ...]);`