### PR TITLE
Weapon adjustments

### DIFF
--- a/stats/research.json
+++ b/stats/research.json
@@ -3202,14 +3202,14 @@
 				"filterParameter": "ImpactClass",
 				"filterValue": "ROCKET",
 				"parameter": "Damage",
-				"value": 35
+				"value": 30
 			},
 			{
 				"class": "Weapon",
 				"filterParameter": "ImpactClass",
 				"filterValue": "ROCKET",
 				"parameter": "RadiusDamage",
-				"value": 35
+				"value": 30
 			}
 		],
 		"statID": "Rocket-Pod",
@@ -3231,14 +3231,14 @@
 				"filterParameter": "ImpactClass",
 				"filterValue": "ROCKET",
 				"parameter": "Damage",
-				"value": 15
+				"value": 20
 			},
 			{
 				"class": "Weapon",
 				"filterParameter": "ImpactClass",
 				"filterValue": "ROCKET",
 				"parameter": "RadiusDamage",
-				"value": 15
+				"value": 20
 			}
 		],
 		"statID": "Rocket-Pod",

--- a/stats/weapons.json
+++ b/stats/weapons.json
@@ -1245,7 +1245,7 @@
 	"Cannon5VulcanMk1": {
 		"buildPoints": 800,
 		"buildPower": 200,
-		"damage": 53,
+		"damage": 52,
 		"designable": 1,
 		"effectSize": 50,
 		"explosionWav": "smlexpl.ogg",


### PR DESCRIPTION
Decreasing the base Damage of the AC to 52 because of being to strong with 53. According to a feedback from Discord member Brutaz the MRP is too powerful in Alpha 06. Therefore the first damage upgrade is decreased to 30 and the second increased to 20.