### PR TITLE
Change Nexus hacking Gamma 9

### DIFF
--- a/script/campaign/cam3-4.js
+++ b/script/campaign/cam3-4.js
@@ -18,7 +18,7 @@ const mis_nexusRes = [
 
 function eventDestroyed(obj)
 {
-	if (obj.player === CAM_NEXUS && obj.type === STRUCTURE && obj.stattype === HQ)
+	if (camGetNexusState() && obj.player === CAM_NEXUS && obj.type === STRUCTURE && obj.stattype === HQ)
 	{
 		camSetNexusState(false);
 		removeTimer("nexusHackFeature");
@@ -47,11 +47,11 @@ function nexusHackFeature()
 
 	switch (difficulty)
 	{
-		case SUPEREASY: hackFailChance = 90; break;
-		case EASY: hackFailChance = 80; break;
-		case MEDIUM: hackFailChance = 70; break;
+		case SUPEREASY: hackFailChance = 95; break;
+		case EASY: hackFailChance = 85; break;
+		case MEDIUM: hackFailChance = 75; break;
 		case HARD: hackFailChance = 65; break;
-		case INSANE: hackFailChance = 60; break;
+		case INSANE: hackFailChance = 55; break;
 		default: hackFailChance = 70;
 	}
 
@@ -66,7 +66,17 @@ function nexusHackFeature()
 // A little suprise absorbption attack when discovering the SW base.
 function takeoverChanceAttack()
 {
-	const CHANCE = (difficulty === INSANE) ? 10 : 5;
+	let chance = 0;
+	switch (difficulty)
+	{
+		case SUPEREASY: chance = 1; break;
+		case EASY: chance = 3; break;
+		case MEDIUM: chance = 5; break;
+		case HARD: chance = 7; break;
+		case INSANE: chance = 9; break;
+		default: chance = 5;
+	}
+
 	const objects = enumArea(0, 0, mapWidth, mapHeight, CAM_HUMAN_PLAYER, false).filter((obj) => (
 		(obj.type !== DROID) || (obj.type === DROID && obj.droidType !== DROID_SUPERTRANSPORTER)
 	));
@@ -74,7 +84,11 @@ function takeoverChanceAttack()
 	for (let i = 0, len = objects.length; i < len; ++i)
 	{
 		const obj = objects[i];
-		if (camRand(100) < CHANCE)
+		if (obj.type === DROID && obj.droidType === DROID_COMMAND)
+		{
+			continue; //A little too hectic to take a Commander immediately.
+		}
+		if (camRand(100) < chance)
 		{
 			if (obj.type === STRUCTURE && obj.stattype === WALL)
 			{
@@ -88,26 +102,23 @@ function takeoverChanceAttack()
 	}
 }
 
-//Destroy some VTOLs initially.
 function destroyPlayerVtols()
 {
-	let vtolBlowupAmount = 0;
-	const vtols = enumArea(0, 0, mapWidth, mapHeight, CAM_HUMAN_PLAYER, false).filter((obj) => (
-		(obj.type === DROID) && (obj.droidType !== DROID_SUPERTRANSPORTER) && isVTOL(obj)
-	));
-
-	switch (difficulty)
+	const hq = getObject("NX-HQ");
+	if (hq === null)
 	{
-		case MEDIUM: vtolBlowupAmount = 0.5; break;
-		case HARD: vtolBlowupAmount = 0.65; break;
-		case INSANE: vtolBlowupAmount = 0.8; break;
-		default: vtolBlowupAmount = 0.5;
+		removeTimer("destroyPlayerVtols");
+		return;
 	}
-
-	for (let i = 0, len = Math.floor(vtolBlowupAmount * vtols.length); i < len; ++i)
+	const __SCAN_RADIUS = 11;
+	const objects = enumRange(hq.x, hq.y, __SCAN_RADIUS, CAM_HUMAN_PLAYER, false);
+	for (let i = 0, len = objects.length; i < len; ++i)
 	{
-		const vtol = vtols[i];
-		camSafeRemoveObject(vtol, true);
+		const obj = objects[i];
+		if (obj.type === DROID && isVTOL(obj))
+		{
+			camSafeRemoveObject(obj, true);
+		}
 	}
 }
 
@@ -116,21 +127,19 @@ function activateNexus()
 	camSetExtraObjectiveMessage(_("Destroy the Nexus HQ to disable the Nexus Intruder Program"));
 	playSound(cam_sounds.nexus.synapticLinksActivated);
 	camSetNexusState(true);
-	setTimer("nexusHackFeature", camSecondsToMilliseconds((difficulty <= MEDIUM) ? 20 : 10));
+	setTimer("nexusHackFeature", camSecondsToMilliseconds((difficulty <= EASY) ? 20 : 10));
+	setTimer("destroyPlayerVtols", camSecondsToMilliseconds(0.2));
 }
 
 function camEnemyBaseDetected_NX_SWBase()
 {
+	if (getObject("NX-HQ") === null)
+	{
+		return; //Probably destroyed through cheats?
+	}
 	camPlayVideos({video: "MB3_4_MSG4", type: MISS_MSG});
 	//Do these before Nexus state activation to prevent sound spam.
-	if (difficulty >= MEDIUM)
-	{
-		queue("destroyPlayerVtols", camSecondsToMilliseconds(0.2));
-	}
-	if (difficulty >= HARD)
-	{
-		queue("takeoverChanceAttack", camSecondsToMilliseconds(0.5));
-	}
+	queue("takeoverChanceAttack", camSecondsToMilliseconds(0.5));
 	queue("activateNexus", camSecondsToMilliseconds(1));
 }
 

--- a/wrf/cam3/cam3-4/labels.json
+++ b/wrf/cam3/cam3-4/labels.json
@@ -231,5 +231,11 @@
 		"id": 1235,
 		"player": 3,
 		"type": 1
+	},
+	"object_11": {
+		"label": "NX-HQ",
+		"id": 237,
+		"player": 3,
+		"type": 1
 	}
 }


### PR DESCRIPTION
Remove destruction of VTOLs at start of SW base being sited, instead, just protect the HQ with a force-field wave against them.

Take over chance attack happens on all difficulties with varied chances now. Commanders ignored for initial hit.

Finally, some added checks to see if the HQ was destroyed before base detection to prevent warnings.