### PR TITLE
Tweaks before 4.5.0

### DIFF
--- a/script/campaign/cam2-6.js
+++ b/script/campaign/cam2-6.js
@@ -3,7 +3,7 @@ include("script/campaign/templates.js");
 
 const mis_collectiveRes = [
 	"R-Defense-WallUpgrade06", "R-Struc-Materials06", "R-Sys-Engineering02",
-	"R-Vehicle-Engine04", "R-Vehicle-Metals05", "R-Cyborg-Metals05",
+	"R-Vehicle-Engine05", "R-Vehicle-Metals05", "R-Cyborg-Metals05",
 	"R-Wpn-Cannon-Accuracy02", "R-Wpn-Cannon-Damage05", "R-Wpn-Cannon-ROF02",
 	"R-Wpn-Flamer-Damage06", "R-Wpn-Flamer-ROF03", "R-Wpn-MG-Damage07",
 	"R-Wpn-MG-ROF03", "R-Wpn-Mortar-Acc02", "R-Wpn-Mortar-Damage06",

--- a/script/campaign/cam2-d.js
+++ b/script/campaign/cam2-d.js
@@ -4,7 +4,7 @@ include("script/campaign/templates.js");
 const MIS_UPLINK_PLAYER = 1; //The satellite uplink player number.
 const mis_collectiveRes = [
 	"R-Defense-WallUpgrade05", "R-Struc-Materials05", "R-Sys-Engineering02",
-	"R-Vehicle-Engine04", "R-Vehicle-Metals05", "R-Cyborg-Metals05",
+	"R-Vehicle-Engine05", "R-Vehicle-Metals05", "R-Cyborg-Metals05",
 	"R-Wpn-Cannon-Accuracy02", "R-Wpn-Cannon-Damage05", "R-Wpn-Cannon-ROF02",
 	"R-Wpn-Flamer-Damage06", "R-Wpn-Flamer-ROF03", "R-Wpn-MG-Damage07",
 	"R-Wpn-MG-ROF03", "R-Wpn-Mortar-Acc02", "R-Wpn-Mortar-Damage05",

--- a/script/campaign/transitionTech.js
+++ b/script/campaign/transitionTech.js
@@ -117,7 +117,7 @@ const mis_betaResearchNew = [
 	"R-Wpn-Bomb02", "R-Wpn-Howitzer-Accuracy01", "R-Wpn-Howitzer-Damage02",
 	"R-Wpn-AAGun-Accuracy02", "R-Wpn-Howitzer-ROF02", "R-Struc-Research-Upgrade06",
 	"R-Struc-VTOLPad-Upgrade03", "R-Wpn-Bomb-Damage02", "R-Wpn-Bomb04",
-	"R-Defense-WallUpgrade06",
+	"R-Defense-WallUpgrade06", "R-Vehicle-Engine05",
 
 	// 8
 	"R-Sys-VTOLCBS-Tower01", "R-Wpn-Cannon4AMk1", "R-Wpn-Mortar3", "R-Wpn-Rocket07-Tank-Killer",

--- a/stats/research.json
+++ b/stats/research.json
@@ -4641,7 +4641,7 @@
 		"imdName": "iceng.pie",
 		"name": "Turbo-Charged Engine Mk2",
 		"requiredResearch": [
-			"R-Vehicle-Body09",
+			"R-Struc-Research-Upgrade04",
 			"R-Vehicle-Engine04"
 		],
 		"researchPoints": 9000,
@@ -4664,6 +4664,7 @@
 		"imdName": "iceng.pie",
 		"name": "Turbo-Charged Engine Mk3",
 		"requiredResearch": [
+			"R-Vehicle-Body09",
 			"R-Vehicle-Engine05"
 		],
 		"researchPoints": 11000,

--- a/stats/research.json
+++ b/stats/research.json
@@ -8752,7 +8752,7 @@
 				"filterParameter": "ImpactClass",
 				"filterValue": "MACHINE GUN",
 				"parameter": "Damage",
-				"value": 5
+				"value": 15
 			}
 		],
 		"statID": "MG1Mk1",

--- a/stats/structuremodifier.json
+++ b/stats/structuremodifier.json
@@ -24,7 +24,7 @@
 		"SOFT": 200
 	},
 	"BUNKER BUSTER": {
-		"BUNKER": 500,
+		"BUNKER": 900,
 		"HARD": 350,
 		"MEDIUM": 200,
 		"SOFT": 100


### PR DESCRIPTION
- Moves Turbo-Charged Engine Mk2 into Beta 7 after the first research module upgrade.
- Makes Bunker Buster 1 shot all bunker busters (at least as far as you have to go up against, last Plasteel upgrades keep them alive).
- Bump Depleted Uranium MG Bullets upgrade so AC doesn't outpace AG during the brief window Gamma 1 starts you with the Mk2 upgrade. AC wins in this window currently due to baseline damage being buffed to 52 and the Nexus cyborg nerf.