### PR TITLE
Allow using map-placed artifacts

### DIFF
--- a/script/campaign/cam1-7.js
+++ b/script/campaign/cam1-7.js
@@ -31,6 +31,7 @@ const mis_newParadigmResClassic = [
 const mis_scavengerResClassic = [
 	"R-Wpn-MG-Damage03", "R-Wpn-Rocket-Damage02"
 ];
+const MIS_NEW_ARTI_LABEL = "newArtiLabel"; //Label for the picked-up artifact once dropped.
 var artiGroup; //Droids that take the artifact
 var enemyHasArtifact; //Do they have the artifact
 var enemyStoleArtifact; //Reached the LZ with the artifact
@@ -109,20 +110,18 @@ function eventGroupLoss(obj, group, newsize)
 	{
 		if (obj.id === droidWithArtiID)
 		{
+			camDeleteArtifact("artifact1", false); //Clear original map-placed artifact if found.
+			//Setup the new artifact.
 			const acrate = addFeature(CAM_ARTIFACT_STAT, obj.x, obj.y);
-			addLabel(acrate, "newArtiLabel");
+			addLabel(acrate, MIS_NEW_ARTI_LABEL);
 
 			if (camClassicMode())
 			{
-				camSetArtifacts({
-					"newArtiLabel": { tech: "R-Wpn-Cannon3Mk1" }
-				});
+				camAddArtifact(MIS_NEW_ARTI_LABEL, "R-Wpn-Cannon3Mk1");
 			}
 			else
 			{
-				camSetArtifacts({
-					"newArtiLabel": { tech: ["R-Wpn-Cannon3Mk1", "R-Wpn-RocketSlow-Damage03"] }
-				});
+				camAddArtifact(MIS_NEW_ARTI_LABEL, ["R-Wpn-Cannon3Mk1", "R-Wpn-RocketSlow-Damage03"]);
 			}
 
 			droidWithArtiID = undefined;
@@ -134,7 +133,7 @@ function eventGroupLoss(obj, group, newsize)
 
 function enemyCanTakeArtifact(label)
 {
-	return label.indexOf("newArtiLabel") !== -1 || label.indexOf("artifactLocation") !== -1;
+	return label.indexOf(MIS_NEW_ARTI_LABEL) !== -1 || label.indexOf("artifact1") !== -1;
 }
 
 //Moves some New Paradigm forces to the artifact

--- a/script/campaign/cam1-7.js
+++ b/script/campaign/cam1-7.js
@@ -284,16 +284,13 @@ function eventStartLevel()
 	//Make sure the New Paradigm and Scavs are allies
 	setAlliance(CAM_NEW_PARADIGM, CAM_SCAV_7, true);
 
-	//Get rid of the already existing crate and replace with another
-	camSafeRemoveObject("artifact1", false);
-
 	if (camClassicMode())
 	{
 		camClassicResearch(mis_newParadigmResClassic, CAM_NEW_PARADIGM);
 		camClassicResearch(mis_scavengerResClassic, CAM_SCAV_7);
 
 		camSetArtifacts({
-			"artifactLocation": { tech: "R-Wpn-Cannon3Mk1" },
+			"artifact1": { tech: "R-Wpn-Cannon3Mk1" },
 		});
 	}
 	else
@@ -316,7 +313,7 @@ function eventStartLevel()
 		}
 
 		camSetArtifacts({
-			"artifactLocation": { tech: ["R-Wpn-Cannon3Mk1", "R-Wpn-RocketSlow-Damage03"] },
+			"artifact1": { tech: ["R-Wpn-Cannon3Mk1", "R-Wpn-RocketSlow-Damage03"] },
 		});
 	}
 

--- a/script/campaign/cam1-d.js
+++ b/script/campaign/cam1-d.js
@@ -165,10 +165,8 @@ function eventStartLevel()
 	startTransporterEntry(tEnt.x, tEnt.y, CAM_HUMAN_PLAYER);
 	setTransporterExit(tExt.x, tExt.y, CAM_HUMAN_PLAYER);
 
-	//Get rid of the already existing crate and replace with another
-	camSafeRemoveObject("artifact1", false);
 	camSetArtifacts({
-		"artifactLocation": { tech: "R-Vehicle-Prop-Hover" }, //SE base
+		"artifact1": { tech: "R-Vehicle-Prop-Hover" }, //SE base
 		"NPFactoryW": { tech: "R-Vehicle-Metals03" }, //West factory
 		"NPFactoryNE": { tech: "R-Vehicle-Body12" }, //Main base factory
 	});

--- a/script/campaign/libcampaign_includes/artifact.js
+++ b/script/campaign/libcampaign_includes/artifact.js
@@ -28,31 +28,57 @@ function camSetArtifacts(artifacts)
 	__camArtifacts = artifacts;
 	for (const alabel in __camArtifacts)
 	{
-		const ai = __camArtifacts[alabel];
-		const pos = camMakePos(alabel);
-		if (camDef(pos.id))
+		__camSetupArtifactData(alabel);
+	}
+}
+
+//;; ## camAddArtifact(artiLabel, artiTech)
+//;;
+//;; Adds another artifact to be managed. Will override existing ones if the names match.
+//;;
+//;; @param {String} artiLabel
+//;; @param {String|Array} artiTech
+//;; @returns {void}
+//;;
+function camAddArtifact(artiLabel, artiTech)
+{
+	if (!camDef(artiLabel) || !camDef(artiTech))
+	{
+		camTrace("Attempt to add new artifact failed due to undefined name or tech parameter");
+		return;
+	}
+	__camArtifacts[artiLabel] = { tech: artiTech };
+	__camSetupArtifactData(artiLabel);
+}
+
+//;; ## camDeleteArtifact(artiLabel)
+//;;
+//;; Deletes the artifact from the list of managed artifacts.
+//;;
+//;; @param {String} artiLabel
+//;; @returns {void}
+//;;
+function camDeleteArtifact(artiLabel)
+{
+	if (!camDef(artiLabel))
+	{
+		camTrace("Tried to delete undefined artifact label");
+		return;
+	}
+	if (!(artiLabel in __camArtifacts))
+	{
+		camTrace("Artifact label doesn't exist in list of artifacts");
+		return;
+	}
+	if (__camArtifacts[artiLabel].placed)
+	{
+		const obj = getObject(__camGetArtifactLabel(artiLabel));
+		if (camDef(obj) && obj !== null)
 		{
-			const obj = getObject(alabel);
-			if (obj && obj.type === FEATURE && obj.stattype === ARTIFACT)
-			{
-				addLabel(obj, __camGetArtifactLabel(alabel));
-				ai.placed = true; // this is an artifact feature on the map itself.
-			}
-			else
-			{
-				// will place when object with this id is destroyed
-				ai.id = "" + pos.id;
-				ai.placed = false;
-			}
-		}
-		else
-		{
-			// received position or area, place immediately
-			const acrate = addFeature(CAM_ARTIFACT_STAT, pos.x, pos.y);
-			addLabel(acrate, __camGetArtifactLabel(alabel));
-			ai.placed = true;
+			camSafeRemoveObject(obj, false);
 		}
 	}
+	delete __camArtifacts[artiLabel];
 }
 
 //;; ## camAllArtifactsPickedUp()
@@ -97,6 +123,34 @@ function camGetArtifacts()
 }
 
 //////////// privates
+
+function __camSetupArtifactData(alabel)
+{
+	const ai = __camArtifacts[alabel];
+	const pos = camMakePos(alabel);
+	if (camDef(pos.id))
+	{
+		const obj = getObject(alabel);
+		if (obj && obj.type === FEATURE && obj.stattype === ARTIFACT)
+		{
+			addLabel(obj, __camGetArtifactLabel(alabel));
+			ai.placed = true; // this is an artifact feature on the map itself.
+		}
+		else
+		{
+			// will place when object with this id is destroyed
+			ai.id = "" + pos.id;
+			ai.placed = false;
+		}
+	}
+	else
+	{
+		// received position or area, place immediately
+		const acrate = addFeature(CAM_ARTIFACT_STAT, pos.x, pos.y);
+		addLabel(acrate, __camGetArtifactLabel(alabel));
+		ai.placed = true;
+	}
+}
 
 function __camGetArtifactLabel(alabel)
 {

--- a/script/campaign/libcampaign_includes/artifact.js
+++ b/script/campaign/libcampaign_includes/artifact.js
@@ -44,7 +44,7 @@ function camAddArtifact(artiLabel, artiTech)
 {
 	if (!camDef(artiLabel) || !camDef(artiTech))
 	{
-		camTrace("Attempt to add new artifact failed due to undefined name or tech parameter");
+		camDebug("Attempt to add new artifact failed due to undefined name or tech parameter");
 		return;
 	}
 	__camArtifacts[artiLabel] = { tech: artiTech };
@@ -58,16 +58,23 @@ function camAddArtifact(artiLabel, artiTech)
 //;; @param {String} artiLabel
 //;; @returns {void}
 //;;
-function camDeleteArtifact(artiLabel)
+function camDeleteArtifact(artiLabel, warnIfNotFound)
 {
+	if (!camDef(warnIfNotFound))
+	{
+		warnIfNotFound = true;
+	}
 	if (!camDef(artiLabel))
 	{
-		camTrace("Tried to delete undefined artifact label");
+		camDebug("Tried to delete undefined artifact label");
 		return;
 	}
 	if (!(artiLabel in __camArtifacts))
 	{
-		camTrace("Artifact label doesn't exist in list of artifacts");
+		if (warnIfNotFound)
+		{
+			camDebug("Artifact label doesn't exist in list of artifacts");
+		}
 		return;
 	}
 	if (__camArtifacts[artiLabel].placed)

--- a/script/campaign/libcampaign_includes/artifact.js
+++ b/script/campaign/libcampaign_includes/artifact.js
@@ -9,6 +9,7 @@
 //;; The argument is a JavaScript map from object labels to artifact description.
 //;; If the label points to a game object, artifact will be placed when this object
 //;; is destroyed; if the label is a position, the artifact will be placed instantly.
+//;; The label can point to a pre-existing feature artifact on the map too.
 //;; Artifact description is a JavaScript object with the following fields:
 //;; * `tech` The technology to grant when the artifact is recovered.
 //;;   Note that this can be made into an array to make artifacts give out
@@ -31,9 +32,18 @@ function camSetArtifacts(artifacts)
 		const pos = camMakePos(alabel);
 		if (camDef(pos.id))
 		{
-			// will place when object with this id is destroyed
-			ai.id = "" + pos.id;
-			ai.placed = false;
+			const obj = getObject(alabel);
+			if (obj && obj.type === FEATURE && obj.stattype === ARTIFACT)
+			{
+				addLabel(obj, __camGetArtifactLabel(alabel));
+				ai.placed = true; // this is an artifact feature on the map itself.
+			}
+			else
+			{
+				// will place when object with this id is destroyed
+				ai.id = "" + pos.id;
+				ai.placed = false;
+			}
 		}
 		else
 		{
@@ -70,15 +80,15 @@ function camGetArtifacts()
 	{
 		const artifact = __camArtifacts[alabel];
 		const __LIB_LABEL = __camGetArtifactLabel(alabel);
-		//libcampaign managed artifact that was placed on the map.
+		const obj = getObject(alabel);
+		//libcampaign managed artifact that was placed on the map (or map placed artifact).
 		if (artifact.placed && getObject(__LIB_LABEL) !== null)
 		{
 			camArti.push(__LIB_LABEL);
 		}
 		//Label for artifacts that will drop after an object gets destroyed. Or is manually managed.
 		//NOTE: Must check for ID since "alabel" could be a AREA/POSITION label.
-		const obj = getObject(alabel);
-		if (obj !== null && camDef(obj.id))
+		else if (obj !== null && camDef(obj.id))
 		{
 			camArti.push(alabel);
 		}

--- a/script/campaign/libcampaign_includes/events.js
+++ b/script/campaign/libcampaign_includes/events.js
@@ -178,6 +178,10 @@ function cam_eventDroidBuilt(droid, structure)
 
 function cam_eventDestroyed(obj)
 {
+	if (obj.type === FEATURE && obj.stattype === ARTIFACT)
+	{
+		return;
+	}
 	__camCheckPlaceArtifact(obj);
 	if (obj.type === DROID)
 	{


### PR DESCRIPTION
This allows the campaign library to notice and use pre-placed artifacts instead of relying on them appearing only by position if you wanted one to appear out in the open.

The means to add and remove artifacts individually is also supported (and used in Alpha 11 for example purposes).

Also noticed that eventDestroyed() runs after eventPickup, so we don't want to run code in that event if the destroyed object is an artifact. Not sure if this is new master behavior or not.