### PR TITLE
Buff MG damage and add new RR ROF upgrade

### DIFF
--- a/script/campaign/transitionTech.js
+++ b/script/campaign/transitionTech.js
@@ -147,7 +147,7 @@ const mis_gammaResearchNew = [
 	// 1
 	"R-Wpn-Howitzer03-Rot", "R-Wpn-MG-Damage09", "R-Struc-Power-Upgrade02", "R-Sys-Engineering03",
 	"R-Wpn-Cannon-Damage07", "R-Wpn-AAGun-Damage04", "R-Defense-WallUpgrade07", "R-Struc-Materials09",
-	"R-Defense-RotHow", "R-Wpn-Howitzer-Damage04", "R-Wpn-Flamer-ROF04",
+	"R-Defense-RotHow", "R-Wpn-Howitzer-Damage04", "R-Wpn-Flamer-ROF04", "R-Wpn-RocketSlow-ROFRR01",
 
 	// 2
 	"R-Wpn-Cannon-Damage08", "R-Wpn-AAGun-Damage05", "R-Wpn-Howitzer-Damage05",

--- a/stats/research.json
+++ b/stats/research.json
@@ -8225,6 +8225,34 @@
 		"subgroupIconID": "IMAGE_RES_GRPROF",
 		"techCode": 1
 	},
+	"R-Wpn-RocketSlow-ROFRR01": {
+		"iconID": "IMAGE_RES_WEAPONTECH",
+		"id": "R-Wpn-RocketSlow-ROFRR01",
+		"name": "Ripple Rocket Rapid Loader",
+		"requiredResearch": [
+			"R-Wpn-Howitzer03-Rot"
+		],
+		"researchPoints": 6000,
+		"researchPower": 187,
+		"results": [
+			{
+				"class": "Weapon",
+				"filterParameter": "Id",
+				"filterValue": "Rocket-IDF",
+				"parameter": "FirePause",
+				"value": -15
+			},
+			{
+				"class": "Weapon",
+				"filterParameter": "Id",
+				"filterValue": "Rocket-IDF",
+				"parameter": "ReloadTime",
+				"value": -15
+			}
+		],
+		"statID": "Rocket-IDF",
+		"subgroupIconID": "IMAGE_RES_GRPROF"
+	},
 	"R-Wpn-Energy-Accuracy01": {
 		"iconID": "IMAGE_RES_WEAPONTECH",
 		"id": "R-Wpn-Energy-Accuracy01",

--- a/stats/weapons.json
+++ b/stats/weapons.json
@@ -1512,7 +1512,7 @@
 	"CyborgChaingun": {
 		"buildPoints": 160,
 		"buildPower": 40,
-		"damage": 20,
+		"damage": 21,
 		"effectSize": 100,
 		"facePlayer": 1,
 		"firePause": 7,
@@ -1707,7 +1707,7 @@
 	"CyborgRotMG": {
 		"buildPoints": 270,
 		"buildPower": 90,
-		"damage": 22,
+		"damage": 23,
 		"effectSize": 100,
 		"facePlayer": 1,
 		"firePause": 5,
@@ -2588,7 +2588,7 @@
 	"MG3-VTOL": {
 		"buildPoints": 250,
 		"buildPower": 50,
-		"damage": 54,
+		"damage": 57,
 		"designable": 1,
 		"effectSize": 150,
 		"facePlayer": 1,
@@ -2625,7 +2625,7 @@
 	"MG3Mk1": {
 		"buildPoints": 250,
 		"buildPower": 50,
-		"damage": 18,
+		"damage": 19,
 		"designable": 1,
 		"effectSize": 150,
 		"facePlayer": 1,
@@ -2695,7 +2695,7 @@
 	"MG4ROTARY-VTOL": {
 		"buildPoints": 500,
 		"buildPower": 100,
-		"damage": 60,
+		"damage": 63,
 		"designable": 1,
 		"effectSize": 100,
 		"facePlayer": 1,
@@ -2732,7 +2732,7 @@
 	"MG4ROTARYMk1": {
 		"buildPoints": 500,
 		"buildPower": 100,
-		"damage": 20,
+		"damage": 21,
 		"designable": 1,
 		"effectSize": 100,
 		"facePlayer": 1,
@@ -3224,7 +3224,7 @@
 	"NX-CyborgChaingun": {
 		"buildPoints": 50,
 		"buildPower": 10,
-		"damage": 22,
+		"damage": 23,
 		"effectSize": 100,
 		"facePlayer": 1,
 		"firePause": 5,


### PR DESCRIPTION
- Adds 1 point of base damage to HMG and AG to help the distance between them and a flamer's periodical damage. Flashlight should still be stronger most of the time than AG, assuming it doesn't miss too much.
- Adds a ROF upgrade for Ripple Rockets after Hellstorm, mostly cause GS and HS have huge splash damage and RR can only hit a single target.

[camBalance.zip](https://github.com/user-attachments/files/16034516/camBalance.zip)
