### PR TITLE
VTOL weapon improvements

### DIFF
--- a/stats/weapons.json
+++ b/stats/weapons.json
@@ -2897,7 +2897,7 @@
 		"weaponEffect": "ANTI AIRCRAFT",
 		"weaponSubClass": "MISSILE",
 		"weaponWav": "rocket.ogg",
-		"weight": 6000
+		"weight": 600
 	},
 	"Missile-LtSAM": {
 		"buildPoints": 800,


### PR DESCRIPTION
Some older feedback was that the VTOL Needle (coming from Nexus VTOLs) was too weak compared to the other weapons. This PR will improve it along with a necessary upgrade to Rail Gun by extension. At the same time, I didn't like VTOL HMG or AG performance or the VTOL Flashlight and Pulse Laser, so we settled on trying to cap ammo attack runs to 6 at most and boosting the VTOL MGs and Lasers.

VTOL MGs have a terrible accuracy that makes testing their true potential volatile and time consuming. Given a flat 10 point buff to both range levels.

Usual tests performed on Gamma 4, 7,  and 9. AG vs Flashlight, Needle vs AC, Rail vs Pulse vs Scourge vs HEAP vs Thermite, etc. against various target types.

ROF increased on VTOL HC by almost half a second to feel more fun to use.

Also HISKI noted a peculiar weight discrepancy with the Vindicator. Likely a typo with it at 6000 when the Avenger sits at 400.