### PR TITLE
Gamma 7 tweaks

### DIFF
--- a/script/campaign/cam3-ad1.js
+++ b/script/campaign/cam3-ad1.js
@@ -173,6 +173,11 @@ function insaneReinforcementSpawn()
 	camSendGenericSpawn(CAM_REINFORCE_GROUND, CAM_NEXUS, CAM_REINFORCE_CONDITION_ARTIFACTS, location, units, limits.minimum, limits.maxRandom);
 }
 
+function startInsaneReinforcementAttack()
+{
+    setTimer("insaneReinforcementSpawn", camMinutesToMilliseconds(4));
+}
+
 function insaneTransporterAttack()
 {
 	const units = {units: cTempl.nxmangel, appended: cTempl.nxmsens};
@@ -480,7 +485,7 @@ function eventStartLevel()
 	if (camAllowInsaneSpawns())
 	{
 		queue("insaneVtolAttack", camMinutesToMilliseconds(3));
-		setTimer("insaneTransporterAttack", camMinutesToMilliseconds(3));
-		setTimer("insaneReinforcementSpawn", camMinutesToMilliseconds(2.5));
+		queue("startInsaneReinforcementAttack", camMinutesToMilliseconds(1.5));
+		setTimer("insaneTransporterAttack", camMinutesToMilliseconds(4));
 	}
 }


### PR DESCRIPTION
Timer for Insane+ transporter and ground reinforcements get increased to four minutes. New function ensures that one of them arrives at the transporter LZ every two minutes.