### PR TITLE
Reinforcement timer adjust

### DIFF
--- a/script/campaign/cam3-ad2.js
+++ b/script/campaign/cam3-ad2.js
@@ -359,7 +359,7 @@ function checkTime()
 		setTimer("phantomFactorySpawn", camChangeOnDiff(camMinutesToMilliseconds(5)));
 		if (camAllowInsaneSpawns())
 		{
-			setTimer("insaneReinforcementSpawn", camMinutesToMilliseconds(3));
+			setTimer("insaneReinforcementSpawn", camMinutesToMilliseconds(3.5));
 			setTimer("insaneTransporterAttack", camMinutesToMilliseconds(3));
 		}
 		removeTimer("checkTime");


### PR DESCRIPTION
Change of the ground reinforcement timer to avoid transporter and ground reinforcement attacks at the same time.