### PR TITLE
PP buff

### DIFF
--- a/stats/research.json
+++ b/stats/research.json
@@ -6107,24 +6107,24 @@
 		"results": [
 			{
 				"class": "Weapon",
-				"filterParameter": "ImpactClass",
-				"filterValue": "MORTARS",
+				"filterParameter": "Id",
+				"filterValue": "Mortar3ROTARYMk1",
 				"parameter": "Damage",
-				"value": 10
+				"value": 20
 			},
 			{
 				"class": "Weapon",
-				"filterParameter": "ImpactClass",
-				"filterValue": "MORTARS",
+				"filterParameter": "Id",
+				"filterValue": "Mortar3ROTARYMk1",
 				"parameter": "RadiusDamage",
-				"value": 10
+				"value": 20
 			},
 			{
 				"class": "Weapon",
-				"filterParameter": "ImpactClass",
-				"filterValue": "MORTARS",
+				"filterParameter": "Id",
+				"filterValue": "Mortar3ROTARYMk1",
 				"parameter": "RepeatDamage",
-				"value": 10
+				"value": 20
 			}
 		],
 		"statID": "Mortar1Mk1",
@@ -6294,14 +6294,14 @@
 				"filterParameter": "ImpactClass",
 				"filterValue": "MORTARS",
 				"parameter": "FirePause",
-				"value": -5
+				"value": -15
 			},
 			{
 				"class": "Weapon",
 				"filterParameter": "ImpactClass",
 				"filterValue": "MORTARS",
 				"parameter": "ReloadTime",
-				"value": -5
+				"value": -15
 			}
 		],
 		"statID": "Mortar1Mk1",

--- a/stats/weapons.json
+++ b/stats/weapons.json
@@ -3123,7 +3123,7 @@
 		"hitpoints": 60,
 		"id": "Mortar3ROTARYMk1",
 		"lightWorld": 1,
-		"longHit": 50,
+		"longHit": 60,
 		"longRange": 2304,
 		"maxElevation": 90,
 		"minRange": 128,


### PR DESCRIPTION
Mortar damage upgrade in Beta 5 increased by 10 points, Mortar ROF upgrade in Beta 5 increased by 10 points, Mortar damage upgrade in Beta 5 only for the PP to keep it stronger than the Bombard. PP accuracy increased by 10 points.