### PR TITLE
Rail Gun ROF upgrade correction

### DIFF
--- a/stats/research.json
+++ b/stats/research.json
@@ -9592,14 +9592,14 @@
 				"filterParameter": "ImpactClass",
 				"filterValue": "GAUSS",
 				"parameter": "FirePause",
-				"value": -10
+				"value": -20
 			},
 			{
 				"class": "Weapon",
 				"filterParameter": "ImpactClass",
 				"filterValue": "GAUSS",
 				"parameter": "ReloadTime",
-				"value": -10
+				"value": -20
 			}
 		],
 		"statID": "RailGun1Mk1",


### PR DESCRIPTION
Thanks to the feedback of HISKI I found an error I made during the rebalance. All calculations were made with a Rail Gun ROF upgrade of 20%. But they got only 10% with the research. This PR correct this error. 